### PR TITLE
Add JSON metadata response to root route

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -33,10 +33,15 @@ from service.common import status  # HTTP Status Codes
 @app.route("/")
 def index():
     """Root URL response"""
-    return (
-        "Reminder: return some useful information in json format about the service here",
-        status.HTTP_200_OK,
-    )
+    app.logger.info("Request for root URL received.")
+
+    response = {
+        "name": "Customers Service",
+        "version": "1.0",
+        "customers_url": "/customers",
+    }
+
+    return jsonify(response), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -68,8 +68,13 @@ class TestYourResourceService(TestCase):
     ######################################################################
 
     def test_index(self):
-        """It should call the home page"""
+        """It should return service metadata on the root URL"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertIsNotNone(data)
+        self.assertEqual(data["name"], "Customers Service")
+        self.assertEqual(data["version"], "1.0")
+        self.assertEqual(data["customers_url"], "/customers")
 
     # Todo: Add your test cases here...


### PR DESCRIPTION
Update the root `/` endpoint to return JSON service metadata, including service name, version, and the customers listing URL, and log requests to the root route. Also extend the existing test to validate the new JSON response.