### PR TITLE
Added idempotency support for create customer endpoint

### DIFF
--- a/service/common/error_handlers.py
+++ b/service/common/error_handlers.py
@@ -70,6 +70,19 @@ def method_not_supported(error):
     )
 
 
+@app.errorhandler(status.HTTP_409_CONFLICT)
+def conflict_error(error):
+    """Handles conflict errors with 409_CONFLICT"""
+    message = str(error)
+    app.logger.warning(message)
+    return (
+        jsonify(
+            status=status.HTTP_409_CONFLICT, error="Conflict", message=message
+        ),
+        status.HTTP_409_CONFLICT,
+    )
+
+
 @app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 def mediatype_not_supported(error):
     """Handles unsupported media requests with 415_UNSUPPORTED_MEDIA_TYPE"""

--- a/service/models.py
+++ b/service/models.py
@@ -5,6 +5,7 @@ All of the models are stored in this module
 """
 
 import logging
+from datetime import datetime, timedelta
 from flask_sqlalchemy import SQLAlchemy
 
 logger = logging.getLogger("flask.app")
@@ -134,3 +135,37 @@ class Customer(db.Model):
         """Returns a Customer with the given userid"""
         logger.info("Processing userid query for %s ...", userid)
         return cls.query.filter(cls.userid == userid).one_or_none()
+
+
+######################################################################
+# IdempotencyKey Model
+######################################################################
+class IdempotencyKey(db.Model):
+    """
+    Stores idempotency keys and their cached responses.
+
+    Think of this like a receipt: when a client sends a request with an
+    Idempotency-Key header, we save the "receipt" here. If they send
+    the same request again (e.g., due to a network retry), we hand back
+    the saved receipt instead of creating a duplicate.
+    """
+
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String(64), nullable=False)
+    endpoint = db.Column(db.String(64), nullable=False)
+    request_payload_hash = db.Column(db.String(64), nullable=False)
+    response_body = db.Column(db.Text, nullable=False)
+    response_status = db.Column(db.Integer, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    # This ensures no two rows can have the same (key, endpoint) combo
+    __table_args__ = (
+        db.UniqueConstraint("key", "endpoint", name="uix_key_endpoint"),
+    )
+
+    def __repr__(self):
+        return f"<IdempotencyKey {self.key} endpoint=[{self.endpoint}]>"
+
+    def is_expired(self, hours=24):
+        """Check if this key is older than the given number of hours"""
+        return datetime.utcnow() - self.created_at > timedelta(hours=hours)

--- a/service/routes.py
+++ b/service/routes.py
@@ -21,9 +21,12 @@ This service implements a REST API that allows you to Create, Read, Update
 and Delete Customer
 """
 
+import hashlib
+import json
+
 from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
-from service.models import Customer
+from service.models import Customer, IdempotencyKey, db
 from service.common import status  # HTTP Status Codes
 
 
@@ -66,23 +69,88 @@ def check_content_type(expected: str) -> None:
 
 
 ######################################################################
-# CREATE A NEW CUSTOMER
+# CREATE A NEW CUSTOMER (with idempotency support)
 ######################################################################
 @app.route("/customers", methods=["POST"])
 def create_customer():
-    """Create a new Customer"""
+    """Create a new Customer
+
+    If the client sends an Idempotency-Key header, the server will:
+    - Return the cached response if the same key+payload was seen before
+    - Reject with 409 if the same key was used with a different payload
+    - Create normally and cache the response if the key is new
+    """
     app.logger.info("Request to create a customer")
     check_content_type("application/json")
 
     data = request.get_json()
     app.logger.debug("Received data: %s", data)
 
+    # --- Idempotency check ---
+    idempotency_key = request.headers.get("Idempotency-Key")
+
+    if idempotency_key:
+        # Hash the payload so we can compare future requests
+        payload_hash = hashlib.sha256(
+            json.dumps(data, sort_keys=True).encode()
+        ).hexdigest()
+
+        # Look up this key in our "receipt drawer"
+        existing = IdempotencyKey.query.filter_by(
+            key=idempotency_key, endpoint="/customers"
+        ).first()
+
+        if existing and not existing.is_expired():
+            # We've seen this key before and it hasn't expired
+            if existing.request_payload_hash == payload_hash:
+                # Same key, same data = safe retry → return cached response
+                app.logger.info(
+                    "Idempotent replay detected for key: %s", idempotency_key
+                )
+                return (
+                    jsonify(json.loads(existing.response_body)),
+                    existing.response_status,
+                )
+            else:
+                # Same key, different data = suspicious → reject
+                app.logger.warning(
+                    "Idempotency key reused with different payload: %s",
+                    idempotency_key,
+                )
+                abort(
+                    status.HTTP_409_CONFLICT,
+                    description="Idempotency key already used with a different payload",
+                )
+
+        if existing and existing.is_expired():
+            # Key expired — clean it up and proceed as new
+            app.logger.info("Expired idempotency key removed: %s", idempotency_key)
+            db.session.delete(existing)
+            db.session.commit()
+
+    # --- Normal create logic ---
     try:
         customer = Customer()
         customer.deserialize(data)
         customer.create()
         app.logger.info("Created customer with id: %s", customer.id)
-        return jsonify(customer.serialize()), status.HTTP_201_CREATED, {
+
+        response_data = customer.serialize()
+        response_status = status.HTTP_201_CREATED
+
+        # Save the "receipt" if an idempotency key was provided
+        if idempotency_key:
+            idem_record = IdempotencyKey(
+                key=idempotency_key,
+                endpoint="/customers",
+                request_payload_hash=payload_hash,
+                response_body=json.dumps(response_data),
+                response_status=response_status,
+            )
+            db.session.add(idem_record)
+            db.session.commit()
+
+        return jsonify(response_data), response_status, {
             "Location": url_for("get_customer", customer_id=customer.id, _external=True)
         }
     except Exception as e:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -21,10 +21,11 @@ TestCustomer API Service Test Suite
 # pylint: disable=duplicate-code
 import os
 import logging
+from datetime import datetime, timedelta
 from unittest import TestCase
 from wsgi import app
 from service.common import status
-from service.models import db, Customer
+from service.models import db, Customer, IdempotencyKey
 from .factories import CustomerFactory
 
 DATABASE_URI = os.getenv(
@@ -57,6 +58,7 @@ class TestCustomerService(TestCase):
     def setUp(self):
         """Runs before each test"""
         self.client = app.test_client()
+        db.session.query(IdempotencyKey).delete()  # clean up idempotency keys
         db.session.query(Customer).delete()  # clean up the last tests
         db.session.commit()
 
@@ -166,4 +168,122 @@ class TestCustomerService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         data = resp.get_json()
         self.assertEqual(data["error"], "Internal Server Error")
+
+    ######################################################################
+    #  I D E M P O T E N C Y   T E S T S
+    ######################################################################
+
+    def test_create_customer_with_idempotency_key(self):
+        """It should create a customer normally when an Idempotency-Key is provided"""
+        payload = {
+            "name": "Idem",
+            "userid": "idem1",
+            "email": "idem1@example.com",
+            "address": "100 Key St",
+        }
+        resp = self.client.post(
+            "/customers",
+            json=payload,
+            headers={"Idempotency-Key": "key-happy-path"},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        data = resp.get_json()
+        self.assertEqual(data["name"], "Idem")
+        self.assertEqual(data["userid"], "idem1")
+
+    def test_create_customer_idempotent_replay(self):
+        """It should return the same response when the same key+payload is sent twice"""
+        payload = {
+            "name": "Replay",
+            "userid": "replay1",
+            "email": "replay1@example.com",
+            "address": "200 Retry Rd",
+        }
+        headers = {"Idempotency-Key": "key-replay"}
+
+        # First request — creates the customer
+        resp1 = self.client.post("/customers", json=payload, headers=headers)
+        self.assertEqual(resp1.status_code, status.HTTP_201_CREATED)
+        data1 = resp1.get_json()
+
+        # Second request — same key, same payload (a retry)
+        resp2 = self.client.post("/customers", json=payload, headers=headers)
+        self.assertEqual(resp2.status_code, status.HTTP_201_CREATED)
+        data2 = resp2.get_json()
+
+        # Should get back the SAME customer id (no duplicate created)
+        self.assertEqual(data1["id"], data2["id"])
+        self.assertEqual(data1["name"], data2["name"])
+
+        # Verify only ONE customer exists in the database
+        all_customers = self.client.get("/customers")
+        self.assertEqual(len(all_customers.get_json()), 1)
+
+    def test_create_customer_same_key_different_payload(self):
+        """It should return 409 Conflict when the same key is reused with different data"""
+        headers = {"Idempotency-Key": "key-conflict"}
+
+        # First request
+        payload1 = {
+            "name": "Original",
+            "userid": "conflict1",
+            "email": "conflict1@example.com",
+        }
+        resp1 = self.client.post("/customers", json=payload1, headers=headers)
+        self.assertEqual(resp1.status_code, status.HTTP_201_CREATED)
+
+        # Second request — same key but DIFFERENT data
+        payload2 = {
+            "name": "Sneaky Different",
+            "userid": "conflict2",
+            "email": "conflict2@example.com",
+        }
+        resp2 = self.client.post("/customers", json=payload2, headers=headers)
+        self.assertEqual(resp2.status_code, status.HTTP_409_CONFLICT)
+
+    def test_create_customer_without_idempotency_key(self):
+        """It should still work normally when no Idempotency-Key header is sent"""
+        payload = {
+            "name": "NoKey",
+            "userid": "nokey1",
+            "email": "nokey1@example.com",
+        }
+        # No Idempotency-Key header — should work exactly as before
+        resp = self.client.post("/customers", json=payload)
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        data = resp.get_json()
+        self.assertEqual(data["name"], "NoKey")
+
+    def test_create_customer_idempotency_key_expired(self):
+        """It should treat an expired key as a new request"""
+        payload = {
+            "name": "Expired",
+            "userid": "expired1",
+            "email": "expired1@example.com",
+        }
+        headers = {"Idempotency-Key": "key-expired"}
+
+        # First request — creates the customer
+        resp1 = self.client.post("/customers", json=payload, headers=headers)
+        self.assertEqual(resp1.status_code, status.HTTP_201_CREATED)
+        data1 = resp1.get_json()
+
+        # Manually age the idempotency key to 25 hours ago (past the 24h window)
+        idem_record = IdempotencyKey.query.filter_by(key="key-expired").first()
+        idem_record.created_at = datetime.utcnow() - timedelta(hours=25)
+        db.session.commit()
+
+        # Send again with a new userid/email (since old customer still exists
+        # with the unique userid, we use different values to avoid DB conflict)
+        payload2 = {
+            "name": "Expired",
+            "userid": "expired2",
+            "email": "expired2@example.com",
+        }
+        resp2 = self.client.post("/customers", json=payload2, headers=headers)
+        self.assertEqual(resp2.status_code, status.HTTP_201_CREATED)
+        data2 = resp2.get_json()
+
+        # Should be a DIFFERENT customer (new ID) since the key expired
+        self.assertNotEqual(data1["id"], data2["id"])
 


### PR DESCRIPTION
## Changes
- Added IdempotencyKey model for storing cached responses
- Modified POST /customers to support Idempotency-Key header
- Added 409 Conflict error handler
- Added 5 new test cases covering idempotent replay, key conflicts, expiration, and backward compatibility

## Acceptance Criteria Covered
- ✅ Same key + same payload = returns cached response (no duplicate)
- ✅ Same key + different payload = 409 Conflict
- ✅ No key = works normally (backward compatible)
- ✅ Expired key = treated as new request
