### PR TITLE
Added GitHub Actions CI workflow for automated testing and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URI: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip pipenv
+          pipenv install --system --dev
+
+      - name: Log CI run
+        run: echo "CI workflow running on $(date) for commit ${{ github.sha }}"
+
+      - name: Run lint checks
+        run: make lint
+
+      - name: Run unit tests
+        run: make test


### PR DESCRIPTION
## Changes
- Added .github/workflows/ci.yml for CI/CD automation

## What it does
- Runs automatically on every push to master and every PR
- Spins up PostgreSQL 15 service for integration tests
- Runs flake8 and pylint quality checks (make lint)
- Runs all unit tests via pytest (make test)
- Failing tests block PR from merging
- Logs a timestamped message for each CI run
