### PR TITLE
Added Codecov integration and CI/coverage badges to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URI: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip pipenv
+          pipenv install --system --dev
+
+      - name: Log CI run
+        run: echo "CI workflow running on $(date) for commit ${{ github.sha }}"
+
+      - name: Run lint checks
+        run: make lint
+
+      - name: Run unit tests with coverage
+        run: |
+          export RETRY_COUNT=1
+          pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml --disable-warnings
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Customers Service
 
+[![CI](https://github.com/CSCI-GA-2820-SP26-001/customers/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP26-001/customers/actions)
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP26-001/customers/branch/master/graph/badge.svg)](https://codecov.io/gh/CSCI-GA-2820-SP26-001/customers)
+
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 


### PR DESCRIPTION
## Changes
- Added .github/workflows/ci.yml with Codecov upload step
- Added CI status badge and Codecov coverage badge to README.md

## What it does
- After tests pass, coverage results are uploaded to Codecov
- CI badge shows passing/failing status and links to Actions dashboard
- Codecov badge shows coverage percentage and links to Codecov dashboard
- Coverage remains at 95%+
