### PR TITLE
Add query customers by name endpoint and tests

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -34,7 +34,7 @@ class Customer(db.Model):
     product_attributes = db.Column(db.String(256), nullable=True)
     assigned_csm = db.Column(db.String(128), nullable=True)
     arr_value = db.Column(db.Float(), nullable=True)
-    
+
     def __repr__(self):
         return f"<Customer {self.name} id=[{self.id}]>"
 
@@ -77,7 +77,17 @@ class Customer(db.Model):
 
     def serialize(self):
         """Serializes a Customer into a dictionary"""
-        return {"id": self.id, "name": self.name, "userid": self.userid, "email": self.email, "address": self.address, "active": self.active, "product_attributes": self.product_attributes, "assigned_csm": self.assigned_csm, "arr_value": self.arr_value}
+        return {
+            "id": self.id,
+            "name": self.name,
+            "userid": self.userid,
+            "email": self.email,
+            "address": self.address,
+            "active": self.active,
+            "product_attributes": self.product_attributes,
+            "assigned_csm": self.assigned_csm,
+            "arr_value": self.arr_value,
+        }
 
     def deserialize(self, data):
         """Deserializes a Customer from a dictionary"""
@@ -96,10 +106,13 @@ class Customer(db.Model):
         except AttributeError as error:
             raise DataValidationError("Invalid attribute: " + error.args[0]) from error
         except KeyError as error:
-            raise DataValidationError("Invalid Customer: missing " + error.args[0]) from error
+            raise DataValidationError(
+                "Invalid Customer: missing " + error.args[0]
+            ) from error
         except TypeError as error:
             raise DataValidationError(
-                "Invalid Customer: body of request contained bad or no data " + str(error)
+                "Invalid Customer: body of request contained bad or no data "
+                + str(error)
             ) from error
         return self
 
@@ -127,7 +140,7 @@ class Customer(db.Model):
             name (string): the name of the Customers you want to match
         """
         logger.info("Processing name query for %s ...", name)
-        return cls.query.filter(cls.name == name)
+        return cls.query.filter(cls.name.ilike(name))
 
     @classmethod
     def find_by_userid(cls, userid):

--- a/service/routes.py
+++ b/service/routes.py
@@ -159,9 +159,14 @@ def delete_customer(customer_id):
 ######################################################################
 @app.route("/customers", methods=["GET"])
 def list_customers():
-    """Get all Customers"""
+    """Get all Customers, optionally filtered by name"""
     app.logger.info("Request to list all customers")
-    customers = Customer.all()
+    name = request.args.get("name")
+    if name:
+        app.logger.info("Filtering customers by name: %s", name)
+        customers = Customer.find_by_name(name)
+    else:
+        customers = Customer.all()
     results = [customer.serialize() for customer in customers]
     app.logger.info("Returning %d customers", len(results))
     return jsonify(results), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -192,3 +192,36 @@ class TestCustomerService(TestCase):
         """It should return 404 when activating a Customer that does not exist"""
         resp = self.client.put("/customers/99999/activate")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_query_customers_by_name(self):
+        """It should return customers filtered by name"""
+        customer1 = CustomerFactory(name="Alice")
+        customer2 = CustomerFactory(name="Bob")
+        customer1.create()
+        customer2.create()
+
+        resp = self.client.get("/customers?name=Alice")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["name"], "Alice")
+
+    def test_query_customers_by_name_case_insensitive(self):
+        """It should return customers filtered by name case-insensitively"""
+        customer = CustomerFactory(name="Alice")
+        customer.create()
+
+        resp = self.client.get("/customers?name=alice")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+
+    def test_query_customers_by_name_no_match(self):
+        """It should return empty list when no customers match"""
+        customer = CustomerFactory(name="Alice")
+        customer.create()
+
+        resp = self.client.get("/customers?name=NoMatch")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 0)


### PR DESCRIPTION
Implements GET /customers?name= to filter customers by name (case-insensitive). Includes updated find_by_name() method and 3 new test cases. Coverage: 96.60%


