### PR TITLE
Add GET /health endpoint (#24)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -45,6 +45,16 @@ def index():
 
 
 ######################################################################
+# HEALTH
+######################################################################
+@app.route("/health")
+def health():
+    """Health check for monitors (e.g. Kubernetes liveness/readiness)"""
+    app.logger.info("Health check requested")
+    return jsonify({"status": "OK"}), status.HTTP_200_OK
+
+
+######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -77,6 +77,14 @@ class TestCustomerService(TestCase):
         self.assertEqual(data["version"], "1.0")
         self.assertEqual(data["customers_url"], "/customers")
 
+    def test_health(self):
+        """It should return JSON health status for probes"""
+        resp = self.client.get("/health")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.content_type, "application/json")
+        data = resp.get_json()
+        self.assertEqual(data, {"status": "OK"})
+
     def test_create_customer(self):
         """It should Create a new Customer"""
         payload = {


### PR DESCRIPTION
## Summary
Implements issue #24: a **GET /health** endpoint for Kubernetes (and other) health probes.

## Behavior
- No authentication
- Returns **200 OK** with JSON `{"status": "OK"}` while the service is running
- Uses `jsonify` so responses are JSON (not HTML)

## Testing
- Added `test_health` in `tests/test_routes.py` (status, Content-Type, body)

Closes #24