### PR TITLE
Added behave to Pipfile dev-packages for BDD testing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,26 +12,19 @@ python-dotenv = "~=1.2.1"
 gunicorn = "~=25.0.0"
 
 [dev-packages]
-# Code Quality
 pylint = "~=4.0.4"
 flake8 = "~=7.3.0"
 black = "~=26.1.0"
-
-# Test-Driven Development
 pytest = "~=9.0.2"
 pytest-pspec = "~=0.0.4"
 pytest-cov = "~=7.0.0"
 factory-boy = "~=3.3.3"
 coverage = "~=7.13.2"
-
-# BDD Testing
-behave = "~=1.2.6"
 selenium = "~=4.27.1"
 requests = "~=2.32.3"
-
-# Utility
 honcho = "~=2.0.0"
 httpie = "~=3.2.4"
+behave = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b9f819918554391616bf459cf3c01a5eee896ec489a758cab9cb1604c0ebec1a"
+            "sha256": "2b50ab8e5a9cdcadc293ffb55121182fa9bff620b67203d5a6a31abe945a6383"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -367,6 +367,15 @@
             "markers": "python_full_version >= '3.10.0'",
             "version": "==4.0.3"
         },
+        "behave": {
+            "hashes": [
+                "sha256:2b8f4b64ed2ea756a5a2a73e23defc1c4631e9e724c499e46661778453ebaf51",
+                "sha256:89bdb62af8fb9f147ce245736a5de69f025e5edfb66f1fbe16c5007493f842c0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.3.3"
+        },
         "black": {
             "hashes": [
                 "sha256:101540cb2a77c680f4f80e628ae98bd2bd8812fb9d72ade4f8995c5ff019e82c",
@@ -536,6 +545,14 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.3.1"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
+        },
         "coverage": {
             "extras": [
                 "toml"
@@ -637,6 +654,22 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==7.13.2"
+        },
+        "cucumber-expressions": {
+            "hashes": [
+                "sha256:8eb5ae46dd03dd37fec1163ace1510529501d7d1868ff372c1ab2cd5aa4543a8",
+                "sha256:f452e6c73258c1677043ad67ad5f538c87284d6b502004720510fb6b7452d9c5"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==19.0.0"
+        },
+        "cucumber-tag-expressions": {
+            "hashes": [
+                "sha256:cca145d677a942c1877e5a2cf13da8c6ec99260988877c817efd284d8455bb56",
+                "sha256:d960383d5885300ebcbcb14e41657946fde2a59d5c0f485eb291bc6a0e228acc"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==9.1.0"
         },
         "defusedxml": {
             "hashes": [
@@ -912,6 +945,21 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==26.0"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:55339ca698019815df3b8e8b550e5933933527e623b0cdf1ca2f404da35ffb47",
+                "sha256:825e1a88e9d9fb481b8d2ca709c6195558b6eaa97c559ad3a9a20aa2d12815a3"
+            ],
+            "version": "==1.21.1"
+        },
+        "parse-type": {
+            "hashes": [
+                "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c",
+                "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1'",
+            "version": "==0.6.6"
         },
         "pathspec": {
             "hashes": [


### PR DESCRIPTION
## Changes
- Added behave to [dev-packages] in Pipfile
- Updated Pipfile.lock with locked versions
## Acceptance Criteria
- ✅ behave is listed under [dev-packages] in Pipfile
- ✅ pipenv install --dev installs behave automatically
- ✅ behave command works in container after install (verified with `behave --version` → 1.3.3)