### PR TITLE
Added Tekton pipeline with clone, lint, and test tasks

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: ci-pipeline
+spec:
+  description: |
+    Clone the repository, then run lint and test tasks in parallel.
+  params:
+    - name: repo-url
+      type: string
+      description: URL of the git repository to clone.
+    - name: revision
+      type: string
+      description: Git revision (branch, tag, or sha) to check out.
+      default: master
+  workspaces:
+    - name: source
+      description: Shared workspace where source code lives between tasks.
+  tasks:
+    - name: clone
+      taskRef:
+        resolver: hub
+        params:
+          - name: catalog
+            value: tekton-catalog-tasks
+          - name: type
+            value: artifact
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.9"
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.revision)
+
+    - name: lint
+      runAfter:
+        - clone
+      taskRef:
+        name: lint
+      workspaces:
+        - name: source
+          workspace: source
+
+    - name: tests
+      runAfter:
+        - clone
+      taskRef:
+        name: tests
+      workspaces:
+        - name: source
+          workspace: source

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: lint
+spec:
+  description: Run flake8 and pylint via the project Makefile.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  steps:
+    - name: run-lint
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "Installing dependencies..."
+        pip install --upgrade pip pipenv
+        pipenv install --system --dev
+        echo "Running lint checks..."
+        make lint
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: tests
+spec:
+  description: Run pytest with coverage via the project Makefile.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  steps:
+    - name: run-tests
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DATABASE_URI
+          value: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "Installing dependencies..."
+        pip install --upgrade pip pipenv
+        pipenv install --system --dev
+        echo "Running tests..."
+        make test


### PR DESCRIPTION
## Changes
- Added .tekton/tasks.yaml defining lint and tests Tasks
- Added .tekton/pipeline.yaml orchestrating clone -> (lint || tests)

## What it does
- Uses git-clone Task from Tekton Hub for cloning
- Runs lint (flake8 + pylint via make lint) and tests (pytest with coverage via make test) in parallel after clone completes

## Acceptance Criteria
- ✅ .tekton/pipeline.yaml and tasks.yaml exist
- ✅ Clone, lint, and test tasks defined and structured to run successfully
- ✅ Lint and test run in parallel (both have runAfter: clone, neither depends on the other)
- ✅ Uses Tekton Hub git-clone task