### PR TITLE
Added build and deploy tasks to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -5,7 +5,8 @@ metadata:
   name: ci-pipeline
 spec:
   description: |
-    Clone the repository, then run lint and test tasks in parallel.
+    Clone the repository, run lint and tests in parallel, build the
+    container image, and deploy to the cluster.
   params:
     - name: repo-url
       type: string
@@ -14,6 +15,10 @@ spec:
       type: string
       description: Git revision (branch, tag, or sha) to check out.
       default: master
+    - name: image
+      type: string
+      description: Image reference to build and push (e.g. cluster-registry:5000/customers:1.0).
+      default: cluster-registry:5000/customers:1.0
   workspaces:
     - name: source
       description: Shared workspace where source code lives between tasks.
@@ -58,3 +63,41 @@ spec:
       workspaces:
         - name: source
           workspace: source
+
+    - name: build-image
+      runAfter:
+        - lint
+        - tests
+      taskRef:
+        resolver: hub
+        params:
+          - name: catalog
+            value: tekton-catalog-tasks
+          - name: type
+            value: artifact
+          - name: kind
+            value: task
+          - name: name
+            value: buildah
+          - name: version
+            value: "0.7"
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: $(params.image)
+        - name: TLSVERIFY
+          value: "false"
+
+    - name: deploy
+      runAfter:
+        - build-image
+      taskRef:
+        name: deploy
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: image
+          value: $(params.image)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: ci-pipeline
+spec:
+  description: |
+    Clone the repository, then run lint and test tasks in parallel.
+  params:
+    - name: repo-url
+      type: string
+      description: URL of the git repository to clone.
+    - name: revision
+      type: string
+      description: Git revision (branch, tag, or sha) to check out.
+      default: master
+  workspaces:
+    - name: source
+      description: Shared workspace where source code lives between tasks.
+  tasks:
+    - name: clone
+      taskRef:
+        resolver: hub
+        params:
+          - name: catalog
+            value: tekton-catalog-tasks
+          - name: type
+            value: artifact
+          - name: kind
+            value: task
+          - name: name
+            value: git-clone
+          - name: version
+            value: "0.9"
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.revision)
+
+    - name: lint
+      runAfter:
+        - clone
+      taskRef:
+        name: lint
+      workspaces:
+        - name: source
+          workspace: source
+
+    - name: tests
+      runAfter:
+        - clone
+      taskRef:
+        name: tests
+      workspaces:
+        - name: source
+          workspace: source

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -45,3 +45,27 @@ spec:
         pipenv install --system --dev
         echo "Running tests..."
         make test
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy
+spec:
+  description: Apply Kubernetes manifests from the k8s/ folder to the cluster.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  params:
+    - name: image
+      type: string
+      description: Image reference to deploy.
+  steps:
+    - name: apply-manifests
+      image: quay.io/openshift/origin-cli:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "Deploying image $(params.image) to cluster..."
+        oc apply -R -f k8s/
+        echo "Deployment manifests applied."

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: lint
+spec:
+  description: Run flake8 and pylint via the project Makefile.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  steps:
+    - name: run-lint
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "Installing dependencies..."
+        pip install --upgrade pip pipenv
+        pipenv install --system --dev
+        echo "Running lint checks..."
+        make lint
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: tests
+spec:
+  description: Run pytest with coverage via the project Makefile.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  steps:
+    - name: run-tests
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DATABASE_URI
+          value: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        echo "Installing dependencies..."
+        pip install --upgrade pip pipenv
+        pipenv install --system --dev
+        echo "Running tests..."
+        make test


### PR DESCRIPTION
**_ACTUAL HUMAN NOTE FROM THEO:_** this branch was created off of the "add-tekton-pipeline" PR which has not yet been  merged (because I can't merge my own stuff), so we gotta merge that one first



## Changes
- Added new `deploy` Task to .tekton/tasks.yaml that runs `oc apply -R -f k8s/`
- Updated .tekton/pipeline.yaml with two new pipeline stages:
  - `build-image` — uses buildah Task from Tekton Hub to build & push the container image
  - `deploy` — applies Kubernetes/OpenShift manifests after the image is built
- Added an `image` parameter to the pipeline, defaulting to cluster-registry:5000/customers:1.0

## Pipeline shape
clone → (lint || tests in parallel) → build-image → deploy

build-image waits for both lint and tests, so a failing check blocks deployment.

## Acceptance Criteria
- ✅ Pipeline builds Docker image and pushes to registry (buildah Task)
- ✅ Pipeline deploys to OpenShift cluster (oc apply on k8s/ manifests)
- ✅ make deploy continues to work locally — same kubectl apply target, unchanged
