### PR TITLE
Add BDD task and GitHub webhook trigger to Tekton pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -19,6 +19,10 @@ spec:
       type: string
       description: Image reference to build and push (e.g. cluster-registry:5000/customers:1.0).
       default: cluster-registry:5000/customers:1.0
+    - name: base-url
+      type: string
+      description: Base URL where the deployed service is reachable from within the cluster.
+      default: http://customers
   workspaces:
     - name: source
       description: Shared workspace where source code lives between tasks.
@@ -101,3 +105,15 @@ spec:
       params:
         - name: image
           value: $(params.image)
+
+    - name: bdd
+      runAfter:
+        - deploy
+      taskRef:
+        name: bdd
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: base-url
+          value: $(params.base-url)

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -69,3 +69,59 @@ spec:
         echo "Deploying image $(params.image) to cluster..."
         oc apply -R -f k8s/
         echo "Deployment manifests applied."
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: bdd
+spec:
+  description: Run Behave BDD tests against the deployed service.
+  workspaces:
+    - name: source
+      description: Workspace containing the cloned source code.
+  params:
+    - name: base-url
+      type: string
+      description: Base URL of the deployed service (e.g. http://customers).
+  steps:
+    - name: run-bdd
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: BASE_URL
+          value: $(params.base-url)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Installing dependencies..."
+        pip install --upgrade pip pipenv
+        pipenv install --system --dev
+
+        echo "Waiting for service to be ready at ${BASE_URL}..."
+        python - <<'PY'
+        import os
+        import time
+        import sys
+        import requests
+
+        base_url = os.environ["BASE_URL"].rstrip("/")
+        url = f"{base_url}/health"
+        deadline = time.time() + 180
+
+        while time.time() < deadline:
+            try:
+                r = requests.get(url, timeout=5)
+                if r.status_code == 200:
+                    print(f"Service healthy: {url}")
+                    sys.exit(0)
+                print(f"Not ready ({r.status_code}): {url}")
+            except Exception as e:  # noqa: BLE001
+                print(f"Not ready: {e}")
+            time.sleep(5)
+
+        raise SystemExit(f"Timed out waiting for {url}")
+        PY
+
+        echo "Running BDD tests with BASE_URL=${BASE_URL}..."
+        make bdd

--- a/.tekton/triggers.yaml
+++ b/.tekton/triggers.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-triggers-role
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-triggers-role
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-sa
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: github-push-binding
+spec:
+  params:
+    - name: repo-url
+      value: $(body.repository.clone_url)
+    - name: revision
+      value: $(body.after)
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: ci-pipeline-template
+spec:
+  params:
+    - name: repo-url
+      description: Git clone URL
+    - name: revision
+      description: Commit SHA
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: ci-pipeline-run-
+      spec:
+        pipelineRef:
+          name: ci-pipeline
+        params:
+          - name: repo-url
+            value: $(tt.params.repo-url)
+          - name: revision
+            value: $(tt.params.revision)
+          - name: image
+            value: cluster-registry:5000/customers:$(tt.params.revision)
+          - name: base-url
+            value: http://customers
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: github-webhook
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: github-push-master
+      interceptors:
+        - ref:
+            name: cel
+          params:
+            - name: filter
+              value: "header.match('X-GitHub-Event', 'push') && body.ref == 'refs/heads/master'"
+      bindings:
+        - ref: github-push-binding
+      template:
+        ref: ci-pipeline-template


### PR DESCRIPTION
Adds a Behave BDD task that runs after deploy using BASE_URL, and Tekton Triggers resources to start the pipeline on pushes to master. (#45)