### PR TITLE
Prep Tekton pipeline for OpenShift deployment

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: ci-pipeline
+  name: cd-pipeline
 spec:
   description: |
     Clone the repository, run lint and tests in parallel, build the

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -30,6 +30,21 @@ spec:
   workspaces:
     - name: source
       description: Workspace containing the cloned source code.
+  sidecars:
+    - name: postgres
+      image: postgres:15-alpine
+      env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: testdb
+      readinessProbe:
+        exec:
+          command: ["pg_isready", "-U", "postgres"]
+        initialDelaySeconds: 5
+        periodSeconds: 5
   steps:
     - name: run-tests
       image: python:3.12-slim
@@ -40,9 +55,14 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-        echo "Installing dependencies..."
+        echo "Installing system dependencies for psycopg..."
+        apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+          gcc libpq-dev make postgresql-client
+        echo "Installing Python dependencies..."
         pip install --upgrade pip pipenv
         pipenv install --system --dev
+        echo "Waiting for postgres sidecar..."
+        until pg_isready -h localhost -U postgres 2>/dev/null; do sleep 1; done
         echo "Running tests..."
         make test
 ---

--- a/.tekton/triggers.yaml
+++ b/.tekton/triggers.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: ci-pipeline-template
+  name: cd-pipeline-template
 spec:
   params:
     - name: repo-url
@@ -53,10 +53,10 @@ spec:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
       metadata:
-        generateName: ci-pipeline-run-
+        generateName: cd-pipeline-run-
       spec:
         pipelineRef:
-          name: ci-pipeline
+          name: cd-pipeline
         params:
           - name: repo-url
             value: $(tt.params.repo-url)
@@ -93,4 +93,4 @@ spec:
       bindings:
         - ref: github-push-binding
       template:
-        ref: ci-pipeline-template
+        ref: cd-pipeline-template

--- a/.tekton/workspace.yaml
+++ b/.tekton/workspace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pipeline-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
- Rename ci-pipeline -> cd-pipeline per homework spec
- Add .tekton/workspace.yaml with PersistentVolumeClaim
- Add postgres sidecar to tests Task so DATABASE_URI resolves inside the Tekton pod (tests require a live postgres)
- Install gcc/libpq-dev/make in tests step (psycopg build deps)