### PR TITLE
Admin UI, BDD Selenium reliability, and DB session fixes

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -143,5 +143,16 @@ spec:
         raise SystemExit(f"Timed out waiting for {url}")
         PY
 
+        echo "Installing Chromium for Selenium BDD..."
+        if command -v apt-get >/dev/null 2>&1; then
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            chromium chromium-driver ca-certificates fonts-liberation \
+            || apt-get install -y -qq chromium
+          export CHROMIUM_BIN="$(command -v chromium || true)"
+          export CHROMEDRIVER_PATH="$(command -v chromedriver || true)"
+        fi
+
         echo "Running BDD tests with BASE_URL=${BASE_URL}..."
+        export HEADLESS=1
         make bdd

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run: ## Run the service
 .PHONY: bdd
 bdd: ## Run BDD tests with Behave
 	$(info Running BDD tests...)
-	behave
+	pipenv run python -m behave
 
 .PHONY: secret
 secret: ## Generate a secret hex key

--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,3 @@ requests = "~=2.32.3"
 honcho = "~=2.0.0"
 httpie = "~=3.2.4"
 behave = "*"
-
-[requires]
-python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2b50ab8e5a9cdcadc293ffb55121182fa9bff620b67203d5a6a31abe945a6383"
+            "sha256": "1dd58d12853b6b14d90beb2bc7ca899756aa2ddbb7670bb087d0a3d509b5a599"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.12"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -26,11 +24,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
-                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+                "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2",
+                "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.1"
+            "version": "==8.3.3"
         },
         "decorator": {
             "hashes": [
@@ -60,12 +58,12 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:4b1ab820ffc316352da7146005a9e66044a131434b17a7d2a9fb0604f1268864",
-                "sha256:b9b88f0ebc5a0fcd1e9e29a1f045f56f5402c6423ee3e3f675f679d0db5345d1"
+                "sha256:aca364c096c81ca11acd4cede0aaeea91ba76ca74e2c0d7f879154db9d890f35",
+                "sha256:b53a7fff1a07b825b962af320554de44ae77a26abfa373711ff3f83d57d3506d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==25.0.0"
+            "version": "==25.0.3"
         },
         "itsdangerous": {
             "hashes": [
@@ -180,11 +178,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
-                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.0"
+            "version": "==26.2"
         },
         "psycopg": {
             "extras": [
@@ -260,12 +258,12 @@
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6",
-                "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"
+                "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a",
+                "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==1.2.1"
+            "markers": "python_version >= '3.10'",
+            "version": "==1.2.2"
         },
         "retry2": {
             "hashes": [
@@ -277,68 +275,72 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:09168817d6c19954d3b7655da6ba87fcb3a62bb575fb396a81a8b6a9fadfe8b5",
-                "sha256:0cc3117db526cad3e61074100bd2867b533e2c7dc1569e95c14089735d6fb4fe",
-                "sha256:181903fe8c1b9082995325f1b2e84ac078b1189e2819380c2303a5f90e114a62",
-                "sha256:1bc3f601f0a818d27bfe139f6766487d9c88502062a2cd3a7ee6c342e81d5047",
-                "sha256:1e6199143d51e3e1168bedd98cc698397404a8f7508831b81b6a29b18b051069",
-                "sha256:2347c3f0efc4de367ba00218e0ae5c4ba2306e47216ef80d6e31761ac97cb0b9",
-                "sha256:261c4b1f101b4a411154f1da2b76497d73abbfc42740029205d4d01fa1052684",
-                "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366",
-                "sha256:37fee2164cf21417478b6a906adc1a91d69ae9aba8f9533e67ce882f4bb1de53",
-                "sha256:3a9a72b0da8387f15d5810f1facca8f879de9b85af8c645138cba61ea147968c",
-                "sha256:3aac08f7546179889c62b53b18ebf1148b10244b3405569c93984b0388d016a7",
-                "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b",
-                "sha256:412f26bb4ba942d52016edc8d12fb15d91d3cd46b0047ba46e424213ad407bcb",
-                "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863",
-                "sha256:4396c948d8217e83e2c202fbdcc0389cf8c93d2c1c5e60fa5c5a955eae0e64be",
-                "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa",
-                "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf",
-                "sha256:52fe29b3817bd191cc20bad564237c808967972c97fa683c04b28ec8979ae36f",
-                "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada",
-                "sha256:585af6afe518732d9ccd3aea33af2edaae4a7aa881af5d8f6f4fe3a368699597",
-                "sha256:590be24e20e2424a4c3c1b0835e9405fa3d0af5823a1a9fc02e5dff56471515f",
-                "sha256:64901e08c33462acc9ec3bad27fc7a5c2b6491665f2aa57564e57a4f5d7c52ad",
-                "sha256:6ac245604295b521de49b465bab845e3afe6916bcb2147e5929c8041b4ec0545",
-                "sha256:6f827fd687fa1ba7f51699e1132129eac8db8003695513fcf13fc587e1bd47a5",
-                "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908",
-                "sha256:716be5bcabf327b6d5d265dbdc6213a01199be587224eb991ad0d37e83d728fd",
-                "sha256:7568fe771f974abadce52669ef3a03150ff03186d8eb82613bc8adc435a03f01",
-                "sha256:77f8071d8fbcbb2dd11b7fd40dedd04e8ebe2eb80497916efedba844298065ef",
-                "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330",
-                "sha256:895296687ad06dc9b11a024cf68e8d9d3943aa0b4964278d2553b86f1b267735",
-                "sha256:8d3b44b3d0ab2f1319d71d9863d76eeb46766f8cf9e921ac293511804d39813f",
-                "sha256:8d679b5f318423eacb61f933a9a0f75535bfca7056daeadbf6bd5bcee6183aee",
-                "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e",
-                "sha256:9094c8b3197db12aa6f05c51c05daaad0a92b8c9af5388569847b03b1007fb1b",
-                "sha256:90bde6c6b1827565a95fde597da001212ab436f1b2e0c2dcc7246e14db26e2a3",
-                "sha256:9397b381dcee8a2d6b99447ae85ea2530dcac82ca494d1db877087a13e38926d",
-                "sha256:93a12da97cca70cea10d4b4fc602589c4511f96c1f8f6c11817620c021d21d00",
-                "sha256:93bb0aae40b52c57fd74ef9c6933c08c040ba98daf23ad33c3f9893494b8d3ce",
-                "sha256:94b1e5f3a5f1ff4f42d5daab047428cd45a3380e51e191360a35cef71c9a7a2a",
-                "sha256:965c62be8256d10c11f8907e7a8d3e18127a4c527a5919d85fa87fd9ecc2cfdc",
-                "sha256:96c7cca1a4babaaf3bfff3e4e606e38578856917e52f0384635a95b226c87764",
-                "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d",
-                "sha256:9d80ea2ac519c364a7286e8d765d6cd08648f5b21ca855a8017d9871f075542d",
-                "sha256:a1e8cc6cc01da346dc92d9509a63033b9b1bda4fed7a7a7807ed385c7dccdc10",
-                "sha256:ab65cb2885a9f80f979b85aa4e9c9165a31381ca322cbde7c638fe6eefd1ec39",
-                "sha256:af865c18752d416798dae13f83f38927c52f085c52e2f32b8ab0fef46fdd02c2",
-                "sha256:b1e14b2f6965a685c7128bd315e27387205429c2e339eeec55cb75ca4ab0ea2e",
-                "sha256:b2a9f9aee38039cf4755891a1e50e1effcc42ea6ba053743f452c372c3152b1b",
-                "sha256:be6c0466b4c25b44c5d82b0426b5501de3c424d7a3220e86cd32f319ba56798e",
-                "sha256:c4e2cc868b7b5208aec6c960950b7bb821f82c2fe66446c92ee0a571765e91a5",
-                "sha256:c805fa6e5d461329fa02f53f88c914d189ea771b6821083937e79550bf31fc19",
-                "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7",
-                "sha256:db23b1bf8cfe1f7fda19018e7207b20cdb5168f83c437ff7e95d19e39289c447",
-                "sha256:e0c05aff5c6b1bb5fb46a87e0f9d2f733f83ef6cbbbcd5c642b6c01678268061",
-                "sha256:e8ac45e8f4eaac0f9f8043ea0e224158855c6a4329fd4ee37c45c61e3beb518e",
-                "sha256:ea3cd46b6713a10216323cda3333514944e510aa691c945334713fca6b5279ff",
-                "sha256:ebf7e1e78af38047e08836d33502c7a278915698b7c2145d045f780201679999",
-                "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e",
-                "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede"
+                "sha256:01146546d84185f12721a1d2ce0c6673451a7894d1460b592d378ca4871a0c72",
+                "sha256:059d7151fff513c53a4638da8778be7fce81a0c4854c7348ebd0c4078ddf28fe",
+                "sha256:0c98c59075b890df8abfcc6ad632879540f5791c68baebacb4f833713b510e75",
+                "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5",
+                "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148",
+                "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7",
+                "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e",
+                "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518",
+                "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7",
+                "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700",
+                "sha256:334edbcff10514ad1d66e3a70b339c0a29886394892490119dbb669627b17717",
+                "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672",
+                "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88",
+                "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f",
+                "sha256:43d044780732d9e0381ac8d5316f95d7f02ef04d6e4ef6dc82379f09795d993f",
+                "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08",
+                "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a",
+                "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3",
+                "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b",
+                "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536",
+                "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0",
+                "sha256:566df36fd0e901625523a5a1835032f1ebdd7f7886c54584143fa6c668b4df3b",
+                "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a",
+                "sha256:5e61abbec255be7b122aa461021daa7c3f310f3e743411a67079f9b3cc91ece3",
+                "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4",
+                "sha256:62557958002b69699bdb7f5137c6714ca1133f045f97b3903964f47db97ea339",
+                "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158",
+                "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066",
+                "sha256:69469ce8ce7a8df4d37620e3163b71238719e1e2e5048d114a1b6ce0fbf8c662",
+                "sha256:6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1",
+                "sha256:74ab4ee7794d7ed1b0c37e7333640e0f0a626fc7b398c07a7aef52f484fddde3",
+                "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5",
+                "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01",
+                "sha256:7d6be30b2a75362325176c036d7fb8d19e8846c77e87683ffaa8177b35135613",
+                "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a",
+                "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0",
+                "sha256:88690f4e1f0fbf5339bedbb127e240fec1fd3070e9934c0b7bef83432f779d2f",
+                "sha256:8a97ac839c2c6672c4865e48f3cbad7152cee85f4233fb4ca6291d775b9b954a",
+                "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e",
+                "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2",
+                "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af",
+                "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014",
+                "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33",
+                "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61",
+                "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d",
+                "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187",
+                "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401",
+                "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b",
+                "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d",
+                "sha256:b95b2f470c1b2683febd2e7eab1d3f0e078c91dbdd0b00e9c645d07a413bb99f",
+                "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba",
+                "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977",
+                "sha256:c338ec6ec01c0bc8e735c58b9f5d51e75bacb6ff23296658826d7cfdfdb8678a",
+                "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe",
+                "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b",
+                "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f",
+                "sha256:d898cc2c76c135ef65517f4ddd7a3512fb41f23087b0650efb3418b8389a3cd1",
+                "sha256:d99945830a6f3e9638d89a28ed130b1eb24c91255e4f24366fbe699b983f29e4",
+                "sha256:da9b91bca419dc9b9267ffadde24eae9b1a6bffcd09d0a207e5e3af99a03ce0d",
+                "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120",
+                "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750",
+                "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0",
+                "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.46"
+            "version": "==2.0.49"
         },
         "typing-extensions": {
             "hashes": [
@@ -350,22 +352,29 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc",
-                "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67"
+                "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50",
+                "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==3.1.5"
+            "version": "==3.1.8"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:08d1de40d251cc3dc4a7a12726721d475ac189e4e583d596ece7422bc176bda3",
-                "sha256:864a0a34af1bd70e1049ba1e61cee843a7252c826d97825fcee9b2fcbd9e1b14"
+                "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753",
+                "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"
             ],
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==4.0.3"
+            "version": "==4.0.4"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309",
+                "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==26.1.0"
         },
         "behave": {
             "hashes": [
@@ -412,138 +421,154 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c",
-                "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"
+                "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+                "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.1.4"
+            "version": "==2026.4.22"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
-                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
-                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
-                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
-                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
-                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
-                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
-                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
-                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
-                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
-                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
-                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
-                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
-                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
-                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
-                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
-                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
-                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
-                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
-                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
-                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
-                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
-                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
-                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
-                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
-                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
-                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
-                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
-                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
-                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
-                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
-                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
-                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
-                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
-                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
-                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
-                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
-                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
-                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
-                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
-                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
-                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
-                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
-                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
-                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
-                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
-                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
-                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
-                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
-                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
-                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
-                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
-                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
-                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
-                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
-                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
-                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
-                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
-                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
-                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
-                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
-                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
-                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
-                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
-                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
-                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
-                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
-                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
-                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
-                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
-                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
-                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
-                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
-                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
-                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
-                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
-                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
-                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
-                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
-                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
-                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
-                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
-                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
-                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
-                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
-                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
-                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
-                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
-                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
-                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
-                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
-                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
-                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
-                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
-                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
-                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
-                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
-                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
-                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
-                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
-                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
-                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
-                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
-                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
-                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
-                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
-                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
-                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
-                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
-                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
-                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
-                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
-                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
+                "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc",
+                "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c",
+                "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67",
+                "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4",
+                "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0",
+                "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c",
+                "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5",
+                "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444",
+                "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153",
+                "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9",
+                "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01",
+                "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217",
+                "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b",
+                "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c",
+                "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a",
+                "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83",
+                "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5",
+                "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7",
+                "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb",
+                "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c",
+                "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1",
+                "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42",
+                "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab",
+                "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df",
+                "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e",
+                "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207",
+                "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18",
+                "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734",
+                "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38",
+                "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110",
+                "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18",
+                "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44",
+                "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d",
+                "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48",
+                "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e",
+                "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5",
+                "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d",
+                "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53",
+                "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790",
+                "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c",
+                "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b",
+                "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116",
+                "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d",
+                "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10",
+                "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6",
+                "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2",
+                "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776",
+                "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a",
+                "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265",
+                "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008",
+                "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943",
+                "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374",
+                "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246",
+                "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e",
+                "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5",
+                "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616",
+                "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15",
+                "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41",
+                "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960",
+                "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752",
+                "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e",
+                "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72",
+                "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7",
+                "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8",
+                "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b",
+                "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4",
+                "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545",
+                "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706",
+                "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366",
+                "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb",
+                "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a",
+                "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e",
+                "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00",
+                "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f",
+                "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a",
+                "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1",
+                "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66",
+                "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356",
+                "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319",
+                "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4",
+                "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad",
+                "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d",
+                "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+                "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7",
+                "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0",
+                "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686",
+                "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34",
+                "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49",
+                "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c",
+                "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1",
+                "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e",
+                "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60",
+                "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0",
+                "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274",
+                "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d",
+                "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0",
+                "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae",
+                "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f",
+                "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d",
+                "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe",
+                "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3",
+                "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393",
+                "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1",
+                "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af",
+                "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44",
+                "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00",
+                "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c",
+                "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3",
+                "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7",
+                "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd",
+                "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e",
+                "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b",
+                "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8",
+                "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259",
+                "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859",
+                "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46",
+                "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30",
+                "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b",
+                "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46",
+                "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24",
+                "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a",
+                "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24",
+                "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc",
+                "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215",
+                "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063",
+                "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832",
+                "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6",
+                "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79",
+                "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.4.4"
+            "version": "==3.4.7"
         },
         "click": {
             "hashes": [
-                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
-                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+                "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2",
+                "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.1"
+            "version": "==8.3.3"
         },
         "colorama": {
             "hashes": [
@@ -558,102 +583,116 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:044c6951ec37146b72a50cc81ef02217d27d4c3640efd2640311393cbbf143d3",
-                "sha256:060ebf6f2c51aff5ba38e1f43a2095e087389b1c69d559fde6049a4b0001320e",
-                "sha256:060ee84f6a769d40c492711911a76811b4befb6fba50abb450371abb720f5bd6",
-                "sha256:10758e0586c134a0bafa28f2d37dd2cdb5e4a90de25c0fc0c77dabbad46eca28",
-                "sha256:13fe81ead04e34e105bf1b3c9f9cdf32ce31736ee5d90a8d2de02b9d3e1bcb82",
-                "sha256:14ae4146465f8e6e6253eba0cccd57423e598a4cb925958b240c805300918343",
-                "sha256:14f500232e521201cf031549fb1ebdfc0a40f401cf519157f76c397e586c3beb",
-                "sha256:1574983178b35b9af4db4a9f7328a18a14a0a0ce76ffaa1c1bacb4cc82089a7c",
-                "sha256:196bfeabdccc5a020a57d5a368c681e3a6ceb0447d153aeccc1ab4d70a5032ba",
-                "sha256:21dd57941804ae2ac7e921771a5e21bbf9aabec317a041d164853ad0a96ce31e",
-                "sha256:264657171406c114787b441484de620e03d8f7202f113d62fcd3d9688baa3e6f",
-                "sha256:27ba1ed6f66b0e2d61bfa78874dffd4f8c3a12f8e2b5410e515ab345ba7bc9c3",
-                "sha256:292250282cf9bcf206b543d7608bda17ca6fc151f4cbae949fc7e115112fbd41",
-                "sha256:2a47a4223d3361b91176aedd9d4e05844ca67d7188456227b6bf5e436630c9a1",
-                "sha256:2a5b567f0b635b592c917f96b9a9cb3dbd4c320d03f4bf94e9084e494f2e8894",
-                "sha256:2ee0e58cca0c17dd9c6c1cdde02bb705c7b3fbfa5f3b0b5afeda20d4ebff8ef4",
-                "sha256:36393bd2841fa0b59498f75466ee9bdec4f770d3254f031f23e8fd8e140ffdd2",
-                "sha256:387a825f43d680e7310e6f325b2167dd093bc8ffd933b83e9aa0983cf6e0a2ef",
-                "sha256:3973f353b2d70bd9796cc12f532a05945232ccae966456c8ed7034cb96bbfd6f",
-                "sha256:3bca209d001fd03ea2d978f8a4985093240a355c93078aee3f799852c23f561a",
-                "sha256:406821f37f864f968e29ac14c3fccae0fec9fdeba48327f0341decf4daf92d7c",
-                "sha256:40ce1ea1e25125556d8e76bd0b61500839a07944cc287ac21d5626f3e620cad5",
-                "sha256:49d49e9a5e9f4dc3d3dac95278a020afa6d6bdd41f63608a76fa05a719d5b66f",
-                "sha256:4a3158dc2dcce5200d91ec28cd315c999eebff355437d2765840555d765a6e5f",
-                "sha256:4f7b71757a3ab19f7ba286e04c181004c1d61be921795ee8ba6970fd0ec91da5",
-                "sha256:59562de3f797979e1ff07c587e2ac36ba60ca59d16c211eceaa579c266c5022f",
-                "sha256:5b20211c47a8abf4abc3319d8ce2464864fa9f30c5fcaf958a3eed92f4f1fef8",
-                "sha256:5bd447332ec4f45838c1ad42268ce21ca87c40deb86eabd59888859b66be22a5",
-                "sha256:6326e18e9a553e674d948536a04a80d850a5eeefe2aae2e6d7cf05d54046c01b",
-                "sha256:6873f0271b4a15a33e7590f338d823f6f66f91ed147a03938d7ce26efd04eee6",
-                "sha256:68c86173562ed4413345410c9480a8d64864ac5e54a5cda236748031e094229f",
-                "sha256:69269ab58783e090bfbf5b916ab3d188126e22d6070bbfc93098fdd474ef937c",
-                "sha256:69e526e14f3f854eda573d3cf40cffd29a1a91c684743d904c33dbdcd0e0f3e7",
-                "sha256:6ae99e4560963ad8e163e819e5d77d413d331fd00566c1e0856aa252303552c1",
-                "sha256:6b8092aa38d72f091db61ef83cb66076f18f02da3e1a75039a4f218629600e04",
-                "sha256:6e5bbb5018bf76a56aabdb64246b5288d5ae1b7d0dd4d0534fe86df2c2992d1c",
-                "sha256:76e06ccacd1fb6ada5d076ed98a8c6f66e2e6acd3df02819e2ee29fd637b76ad",
-                "sha256:78f45d21dc4d5d6bd29323f0320089ef7eae16e4bef712dff79d184fa7330af3",
-                "sha256:79f6506a678a59d4ded048dc72f1859ebede8ec2b9a2d509ebe161f01c2879d3",
-                "sha256:7be4d613638d678b2b3773b8f687537b284d7074695a43fe2fbbfc0e31ceaed1",
-                "sha256:7c79ad5c28a16a1277e1187cf83ea8dafdcc689a784228a7d390f19776db7c31",
-                "sha256:7de326f80e3451bd5cc7239ab46c73ddb658fe0b7649476bc7413572d36cd548",
-                "sha256:7f9405ab4f81d490811b1d91c7a20361135a2df4c170e7f0b747a794da5b7f23",
-                "sha256:838943bea48be0e2768b0cf7819544cdedc1bbb2f28427eabb6eb8c9eb2285d3",
-                "sha256:88a800258d83acb803c38175b4495d293656d5fac48659c953c18e5f539a274b",
-                "sha256:89567798404af067604246e01a49ef907d112edf2b75ef814b1364d5ce267031",
-                "sha256:8a0b33e9fd838220b007ce8f299114d406c1e8edb21336af4c97a26ecfd185aa",
-                "sha256:8be48da4d47cc68754ce643ea50b3234557cbefe47c2f120495e7bd0a2756f2b",
-                "sha256:9074896edd705a05769e3de0eac0a8388484b503b68863dd06d5e473f874fd47",
-                "sha256:93b57142f9621b0d12349c43fc7741fe578e4bc914c1e5a54142856cfc0bf421",
-                "sha256:93d1d25ec2b27e90bcfef7012992d1f5121b51161b8bffcda756a816cf13c2c3",
-                "sha256:9779310cb5a9778a60c899f075a8514c89fa6d10131445c2207fc893e0b14557",
-                "sha256:97e596de8fa9bada4d88fde64a3f4d37f1b6131e4faa32bad7808abc79887ddc",
-                "sha256:9b2f4714bb7d99ba3790ee095b3b4ac94767e1347fe424278a0b10acb3ff04fe",
-                "sha256:9c9bdea644e94fd66d75a6f7e9a97bb822371e1fe7eadae2cacd50fcbc28e4dc",
-                "sha256:9cc7573518b7e2186bd229b1a0fe24a807273798832c27032c4510f47ffdb896",
-                "sha256:9f93959ee0c604bccd8e0697be21de0887b1f73efcc3aa73a3ec0fd13feace92",
-                "sha256:a360a8baeb038928ceb996f5623a4cd508728f8f13e08d4e96ce161702f3dd99",
-                "sha256:a43d34ce714f4ca674c0d90beb760eb05aad906f2c47580ccee9da8fe8bfb417",
-                "sha256:a55516c68ef3e08e134e818d5e308ffa6b1337cc8b092b69b24287bf07d38e31",
-                "sha256:a7fc042ba3c7ce25b8a9f097eb0f32a5ce1ccdb639d9eec114e26def98e1f8a4",
-                "sha256:abaea04f1e7e34841d4a7b343904a3f59481f62f9df39e2cd399d69a187a9660",
-                "sha256:ae47d8dcd3ded0155afbb59c62bd8ab07ea0fd4902e1c40567439e6db9dcaf2f",
-                "sha256:b01899e82a04085b6561eb233fd688474f57455e8ad35cd82286463ba06332b7",
-                "sha256:b3becbea7f3ce9a2d4d430f223ec15888e4deb31395840a79e916368d6004cce",
-                "sha256:b780090d15fd58f07cf2011943e25a5f0c1c894384b13a216b6c86c8a8a7c508",
-                "sha256:b7fc50d2afd2e6b4f6f2f403b70103d280a8e0cb35320cbbe6debcda02a1030b",
-                "sha256:bff1b04cb9d4900ce5c56c4942f047dc7efe57e2608cb7c3c8936e9970ccdbee",
-                "sha256:c1ea8ca9db5e7469cd364552985e15911548ea5b69c48a17291f0cac70484b2e",
-                "sha256:c6cadac7b8ace1ba9144feb1ae3cb787a6065ba6d23ffc59a934b16406c26573",
-                "sha256:c6f141b468740197d6bd38f2b26ade124363228cc3f9858bd9924ab059e00059",
-                "sha256:ca9566769b69a5e216a4e176d54b9df88f29d750c5b78dbb899e379b4e14b30c",
-                "sha256:d0ba505e021557f7f8173ee8cd6b926373d8653e5ff7581ae2efce1b11ef4c27",
-                "sha256:d6d16b0f71120e365741bca2cb473ca6fe38930bc5431c5e850ba949f708f892",
-                "sha256:d7f63ce526a96acd0e16c4af8b50b64334239550402fb1607ce6a584a6d62ce9",
-                "sha256:e080afb413be106c95c4ee96b4fffdc9e2fa56a8bbf90b5c0918e5c4449412f5",
-                "sha256:e4121a90823a063d717a96e0a0529c727fb31ea889369a0ee3ec00ed99bf6859",
-                "sha256:e64fa5a1e41ce5df6b547cbc3d3699381c9e2c2c369c67837e716ed0f549d48e",
-                "sha256:e79a8c7d461820257d9aa43716c4efc55366d7b292e46b5b37165be1d377405d",
-                "sha256:ed2bce0e7bfa53f7b0b01c722da289ef6ad4c18ebd52b1f93704c21f116360c8",
-                "sha256:ed75de7d1217cf3b99365d110975f83af0528c849ef5180a12fd91b5064df9d6",
-                "sha256:ee68e5a4e3e5443623406b905db447dceddffee0dceb39f4e0cd9ec2a35004b5",
-                "sha256:eeea10169fac01549a7921d27a3e517194ae254b542102267bef7a93ed38c40e",
-                "sha256:f06799ae1bdfff7ccb8665d75f8291c69110ba9585253de254688aa8a1ccc6c5",
-                "sha256:f0d7fea9d8e5d778cd5a9e8fc38308ad688f02040e883cdc13311ef2748cb40f",
-                "sha256:f106b2af193f965d0d3234f3f83fc35278c7fb935dfbde56ae2da3dd2c03b84d",
-                "sha256:f4af3b01763909f477ea17c962e2cca8f39b350a4e46e3a30838b2c12e31b81b",
-                "sha256:f61d349f5b7cd95c34017f1927ee379bfbe9884300d74e07cf630ccf7a610c1b",
-                "sha256:f674f59712d67e841525b99e5e2b595250e39b529c3bda14764e4f625a3fa01f",
-                "sha256:f819c727a6e6eeb8711e4ce63d78c620f69630a2e9d53bc95ca5379f57b6ba94",
-                "sha256:f9ab1d5b86f8fbc97a5b3cd6280a3fd85fef3b028689d8a2c00918f0d82c728c",
-                "sha256:fae91dfecd816444c74531a9c3d6ded17a504767e97aa674d44f638107265b99"
+                "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256",
+                "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b",
+                "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5",
+                "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d",
+                "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a",
+                "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969",
+                "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642",
+                "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87",
+                "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740",
+                "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215",
+                "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d",
+                "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422",
+                "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8",
+                "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911",
+                "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b",
+                "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587",
+                "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8",
+                "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606",
+                "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9",
+                "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf",
+                "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633",
+                "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6",
+                "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43",
+                "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2",
+                "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61",
+                "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930",
+                "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc",
+                "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247",
+                "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75",
+                "sha256:3e1bb5f6c78feeb1be3475789b14a0f0a5b47d505bfc7267126ccbd50289999e",
+                "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376",
+                "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01",
+                "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1",
+                "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3",
+                "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743",
+                "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9",
+                "sha256:52f444e86475992506b32d4e5ca55c24fc88d73bcbda0e9745095b28ef4dc0cf",
+                "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e",
+                "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1",
+                "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd",
+                "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b",
+                "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab",
+                "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d",
+                "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a",
+                "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0",
+                "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510",
+                "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f",
+                "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0",
+                "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8",
+                "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf",
+                "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209",
+                "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9",
+                "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3",
+                "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3",
+                "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d",
+                "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd",
+                "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2",
+                "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882",
+                "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09",
+                "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea",
+                "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c",
+                "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562",
+                "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3",
+                "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806",
+                "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e",
+                "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878",
+                "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e",
+                "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9",
+                "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45",
+                "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29",
+                "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4",
+                "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c",
+                "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479",
+                "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400",
+                "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c",
+                "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a",
+                "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf",
+                "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686",
+                "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de",
+                "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028",
+                "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0",
+                "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179",
+                "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16",
+                "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85",
+                "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a",
+                "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0",
+                "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810",
+                "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161",
+                "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607",
+                "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26",
+                "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819",
+                "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40",
+                "sha256:e0723d2c96324561b9aa76fb982406e11d93cdb388a7a7da2b16e04719cf7ca5",
+                "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15",
+                "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0",
+                "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90",
+                "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0",
+                "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6",
+                "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a",
+                "sha256:eb7fdf1ef130660e7415e0253a01a7d5a88c9c4d158bcf75cbbd922fd65a5b58",
+                "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b",
+                "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17",
+                "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5",
+                "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664",
+                "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0",
+                "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==7.13.2"
+            "version": "==7.13.5"
         },
         "cucumber-expressions": {
             "hashes": [
@@ -698,11 +737,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:93503165c165d330260e4379fd6dc07c94da90c611ed3191a0174d2ab9966a42",
-                "sha256:b76a68163aa5f171d260fc24827a8349bc1db672f6a665359e8d0095e8135d30"
+                "sha256:20f3a6ec8c266b74d4c554e34118b21c3c2056c0b4a519d15c8decb3a4e6e795",
+                "sha256:71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==40.1.2"
+            "version": "==40.15.0"
         },
         "flake8": {
             "hashes": [
@@ -712,6 +751,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==7.3.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
+                "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.16.0"
         },
         "honcho": {
             "hashes": [
@@ -732,11 +779,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
-                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
+                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.11"
+            "version": "==3.13"
         },
         "iniconfig": {
             "hashes": [
@@ -748,11 +795,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1",
-                "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187"
+                "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d",
+                "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"
             ],
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==7.0.0"
+            "version": "==8.0.1"
         },
         "markdown-it-py": {
             "hashes": [
@@ -938,20 +985,28 @@
             "markers": "python_version >= '3.8'",
             "version": "==1.1.0"
         },
+        "outcome": {
+            "hashes": [
+                "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8",
+                "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0.post0"
+        },
         "packaging": {
             "hashes": [
-                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
-                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.0"
+            "version": "==26.2"
         },
         "parse": {
             "hashes": [
-                "sha256:55339ca698019815df3b8e8b550e5933933527e623b0cdf1ca2f404da35ffb47",
-                "sha256:825e1a88e9d9fb481b8d2ca709c6195558b6eaa97c559ad3a9a20aa2d12815a3"
+                "sha256:d4987d68ccf08b6ba3bf80b5004ff7de61c4337cba2d8350ae5c9925794979d9",
+                "sha256:eea8ed34e2614cea65d9c1d4af9cb68cce26aea13d44bdcaf83c1b40884fe945"
             ],
-            "version": "==1.21.1"
+            "version": "==1.22.0"
         },
         "parse-type": {
             "hashes": [
@@ -963,27 +1018,27 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
-                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+                "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a",
+                "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.4"
+            "version": "==1.1.1"
         },
         "pip": {
             "hashes": [
-                "sha256:3ce220a0a17915972fbf1ab451baae1521c4539e778b28127efa79b974aff0fa",
-                "sha256:98436feffb9e31bc9339cf369fd55d3331b1580b6a6f1173bacacddcf9c34754"
+                "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1",
+                "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==26.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==26.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda",
-                "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"
+                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
+                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.5.1"
+            "version": "==4.9.6"
         },
         "pluggy": {
             "hashes": [
@@ -1011,20 +1066,20 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
-                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.19.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:63e06a37d5922555ee2c20963eb42559918c20bd2b21244e4ef426e7c43b92e0",
-                "sha256:d9b71674e19b1c36d79265b5887bf8e55278cbe236c9e95d22dc82cf044fdbd2"
+                "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2",
+                "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==4.0.4"
+            "version": "==4.0.5"
         },
         "pysocks": {
             "hashes": [
@@ -1037,12 +1092,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
-                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.0.2"
+            "version": "==9.0.3"
         },
         "pytest-cov": {
             "hashes": [
@@ -1117,6 +1172,7 @@
                 "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
                 "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.32.5"
         },
@@ -1130,19 +1186,28 @@
         },
         "rich": {
             "hashes": [
-                "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69",
-                "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8"
+                "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
+                "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==14.3.2"
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==15.0.0"
+        },
+        "selenium": {
+            "hashes": [
+                "sha256:5296c425a75ff1b44d0d5199042b36a6d1ef76c04fb775b97b40be739a9caae2",
+                "sha256:b89b1f62b5cfe8025868556fe82360d6b649d464f75d2655cb966c8f8447ea18"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.27.1"
         },
         "setuptools": {
             "hashes": [
-                "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70",
-                "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"
+                "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9",
+                "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==80.10.2"
+            "version": "==82.0.1"
         },
         "six": {
             "hashes": [
@@ -1152,6 +1217,21 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
+        "sniffio": {
+            "hashes": [
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
+        },
         "tomlkit": {
             "hashes": [
                 "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680",
@@ -1160,13 +1240,56 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.14.0"
         },
+        "trio": {
+            "hashes": [
+                "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b",
+                "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.33.0"
+        },
+        "trio-websocket": {
+            "hashes": [
+                "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae",
+                "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        },
         "urllib3": {
+            "extras": [
+                "socks"
+            ],
             "hashes": [
                 "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
                 "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.6.3"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98",
+                "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
+        },
+        "wsproto": {
+            "hashes": [
+                "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584",
+                "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==1.3.2"
         }
     }
 }

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,20 +1,161 @@
 """
-BDD Environment Setup for Customer Service
+BDD environment: Selenium WebDriver (no Python HTTP client in steps).
 """
 import os
-import requests
+import uuid
+
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+def _chrome_options():
+    opts = Options()
+    opts.set_capability("pageLoadStrategy", "eager")
+    if os.environ.get("HEADLESS", "1").lower() not in ("0", "false", "no"):
+        opts.add_argument("--headless=new")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--window-size=1280,900")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument("--remote-allow-origins=*")
+    opts.add_argument("--disable-features=TranslateUI")
+    opts.add_argument("--disable-renderer-backgrounding")
+
+    chromium = os.environ.get("CHROMIUM_BIN")
+    if chromium:
+        opts.binary_location = chromium
+    return opts
+
+
+def _start_browser(context):
+    opts = _chrome_options()
+    chromedriver = os.environ.get("CHROMEDRIVER_PATH")
+    if chromedriver:
+        from selenium.webdriver.chrome.service import Service  # pylint: disable=import-outside-toplevel
+
+        service = Service(chromedriver)
+        context.driver = webdriver.Chrome(service=service, options=opts)
+    else:
+        context.driver = webdriver.Chrome(options=opts)
+    context.driver.implicitly_wait(2)
+    context.driver.set_page_load_timeout(90)
+    context.driver.set_script_timeout(180)
+    context.driver.get(f"{context.BASE_URL}/admin")
+    WebDriverWait(context.driver, 60).until(
+        EC.presence_of_element_located((By.ID, "admin-page"))
+    )
+
+
+def _restart_browser(context):
+    try:
+        context.driver.quit()
+    except Exception:  # pylint: disable=broad-except
+        pass
+    _start_browser(context)
 
 
 def before_all(context):
-    context.BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080")
-    context.headers = {"Content-Type": "application/json"}
-    context.resp = None
+    context.BASE_URL = os.environ.get("BASE_URL", "http://localhost:8080").rstrip("/")
+    _start_browser(context)
+
+
+def after_all(context):
+    driver = getattr(context, "driver", None)
+    if driver:
+        driver.quit()
 
 
 def before_scenario(context, scenario):
     context.created_customer_ids = []
+    context.last_http_status = None
+    context.health_response_text = None
+    context.bdd_user_suffix = uuid.uuid4().hex[:10]
+    try:
+        _browser_delete_all_customers(context)
+    except WebDriverException:
+        _restart_browser(context)
+        try:
+            _browser_delete_all_customers(context)
+        except WebDriverException:
+            pass
+
+
+def _browser_delete_all_customers(context):
+    driver = context.driver
+    base = context.BASE_URL.rstrip("/")
+    driver.set_page_load_timeout(90)
+    driver.set_script_timeout(180)
+    driver.get(f"{base}/admin")
+    WebDriverWait(driver, 45).until(
+        EC.presence_of_element_located((By.ID, "admin-page"))
+    )
+    ok = driver.execute_async_script(
+        """
+        const done = arguments[arguments.length - 1];
+        const base = arguments[0];
+        (async () => {
+          try {
+            const r = await fetch(base + '/customers', {
+              headers: { Accept: 'application/json' }
+            });
+            if (!r.ok) { done(false); return; }
+            const rows = await r.json();
+            if (!Array.isArray(rows)) { done(false); return; }
+            for (const c of rows) {
+              try {
+                await fetch(base + '/customers/' + c.id, { method: 'DELETE' });
+              } catch (e2) {}
+            }
+            done(true);
+          } catch (e) {
+            done(false);
+          }
+        })();
+        """,
+        base,
+    )
+    return bool(ok)
+
+
+def _cleanup_created_customers(context):
+    """DELETE created rows using same-origin fetch from /admin (browser context)."""
+    driver = context.driver
+    base = context.BASE_URL.rstrip("/")
+    ids = list(getattr(context, "created_customer_ids", []))
+    if not ids:
+        return
+    try:
+        driver.set_page_load_timeout(90)
+        driver.get(f"{base}/admin")
+        WebDriverWait(driver, 45).until(
+            EC.presence_of_element_located((By.ID, "admin-page"))
+        )
+    except WebDriverException:
+        return
+    except Exception:  # pylint: disable=broad-except
+        return
+    for cid in ids:
+        try:
+            driver.execute_async_script(
+                """
+                const done = arguments[arguments.length - 1];
+                const url = arguments[0];
+                fetch(url, { method: 'DELETE' })
+                  .then(() => done(true))
+                  .catch(() => done(false));
+                """,
+                f"{base}/customers/{cid}",
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass
 
 
 def after_scenario(context, scenario):
-    for customer_id in getattr(context, "created_customer_ids", []):
-        requests.delete(f"{context.BASE_URL}/customers/{customer_id}", timeout=10)
+    try:
+        _cleanup_created_customers(context)
+    except WebDriverException:
+        pass

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -1,128 +1,273 @@
 """
-Step definitions for Customer Service BDD tests
+BDD step definitions: drive the manager admin UI at /admin with Selenium.
 """
+# pylint: disable=missing-function-docstring,function-redefined
+
 import json
-import requests
-from behave import given, when, then
+
+from behave import given, then, when
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import Select, WebDriverWait
+
+ELLIPSIS = "\u2026"
+
+
+def _scoped_userid(context, raw):
+    suf = getattr(context, "bdd_user_suffix", "") or ""
+    return f"{raw}_{suf}" if suf else raw
+
+
+def _scoped_email(context, raw):
+    suf = getattr(context, "bdd_user_suffix", "") or ""
+    if not suf or "@" not in raw:
+        return raw
+    local, _, domain = raw.partition("@")
+    return f"{local}+{suf}@{domain}"
+
+
+def _wait_admin_request_done(driver, timeout=20):
+    """Wait until status line is non-empty and not in a loading state."""
+
+    def done(drv):
+        try:
+            msg = drv.find_element(By.ID, "admin-status").text
+        except Exception:  # pylint: disable=broad-except
+            return False
+        if not msg.strip():
+            return False
+        if ELLIPSIS in msg or msg.endswith("..."):
+            return False
+        return True
+
+    WebDriverWait(driver, timeout).until(done)
+
+
+def _open_admin(context):
+    d = context.driver
+    base = context.BASE_URL.rstrip("/")
+    want = f"{base}/admin"
+    try:
+        cur = d.current_url.split("#")[0].rstrip("/")
+    except Exception:  # pylint: disable=broad-except
+        cur = ""
+    want_norm = want.rstrip("/")
+    if cur == want_norm or (cur.startswith(base) and cur.endswith("/admin")):
+        d.refresh()
+        WebDriverWait(d, 60).until(
+            EC.presence_of_element_located((By.ID, "admin-page"))
+        )
+        return
+    d.set_page_load_timeout(90)
+    d.get(want)
+    WebDriverWait(d, 60).until(
+        EC.presence_of_element_located((By.ID, "admin-page"))
+    )
+
+
+def _fill_input(driver, el_id, text):
+    el = driver.find_element(By.ID, el_id)
+    driver.execute_script("arguments[0].value = '';", el)
+    el.click()
+    el.send_keys(text)
+
+
+def _select_operation(driver, value):
+    sel = Select(driver.find_element(By.ID, "admin-operation"))
+    sel.select_by_value(value)
+
+
+def _click_send(driver):
+    driver.find_element(By.ID, "btn-execute").click()
+
+
+def _admin_result_text(driver):
+    return driver.find_element(By.ID, "admin-result").text.strip()
+
+
+def _parse_admin_json(driver):
+    raw = _admin_result_text(driver)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
 
 
 @given("the server is running")
 def step_server_is_running(context):
-    resp = requests.get(context.BASE_URL + "/health", timeout=10)
-    assert resp.status_code == 200, f"Server not running — got {resp.status_code}"
+    d = context.driver
+    base = context.BASE_URL.rstrip("/")
+    ok = d.execute_async_script(
+        """
+        const done = arguments[arguments.length - 1];
+        const u = arguments[0];
+        fetch(u)
+          .then((r) => r.text().then((t) =>
+            done((r.status === 200 && t.includes("OK")) ? 1 : 0)
+          ))
+          .catch(() => done(0));
+        """,
+        f"{base}/health",
+    )
+    assert int(ok) == 1, "service not reachable or /health did not return OK"
 
 
 @given('a customer exists with name "{name}", userid "{userid}", email "{email}"')
 def step_create_customer_background(context, name, userid, email):
-    payload = {"name": name, "userid": userid, "email": email}
-    resp = requests.post(
-        context.BASE_URL + "/customers",
-        json=payload,
-        headers=context.headers,
-        timeout=10,
-    )
-    assert resp.status_code == 201, f"Failed to create customer: {resp.text}"
-    context.customer = resp.json()
-    context.created_customer_ids.append(context.customer["id"])
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "create")
+    _fill_input(d, "customer-name", name)
+    _fill_input(d, "customer-userid", _scoped_userid(context, userid))
+    _fill_input(d, "customer-email", _scoped_email(context, email))
+    _click_send(d)
+    _wait_admin_request_done(d)
+    body = _parse_admin_json(d)
+    assert body and body.get("id"), f"create failed: {_admin_result_text(d)}"
+    context.customer = body
+    context.created_customer_ids.append(int(body["id"]))
 
 
 @when('I visit the "{endpoint}" endpoint')
 def step_visit_endpoint(context, endpoint):
-    context.resp = requests.get(
-        f"{context.BASE_URL}/{endpoint}", timeout=10
-    )
+    d = context.driver
+    ep = endpoint.strip().lower()
+    base = context.BASE_URL.rstrip("/")
+    if ep == "health":
+        payload = d.execute_async_script(
+            """
+            const done = arguments[arguments.length - 1];
+            const u = arguments[0];
+            fetch(u)
+              .then((r) => r.text().then((t) =>
+                done(JSON.stringify({ status: r.status, body: t }))
+              ))
+              .catch(() => done(JSON.stringify({ status: 0, body: "" })));
+            """,
+            f"{base}/health",
+        )
+        data = json.loads(payload)
+        context.last_http_status = int(data["status"])
+        context.health_response_text = data.get("body", "")
+        return
+    d.set_page_load_timeout(90)
+    d.get(f"{context.BASE_URL}/{endpoint}")
+    context.last_http_status = None
 
 
 @when("I create a customer with the following data")
 def step_create_customer(context):
     row = context.table[0]
-    payload = {
-        "name": row["name"],
-        "userid": row["userid"],
-        "email": row["email"],
-    }
-    context.resp = requests.post(
-        context.BASE_URL + "/customers",
-        json=payload,
-        headers=context.headers,
-        timeout=10,
-    )
-    if context.resp.status_code == 201:
-        context.created_customer_ids.append(context.resp.json()["id"])
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "create")
+    _fill_input(d, "customer-name", row["name"])
+    _fill_input(d, "customer-userid", _scoped_userid(context, row["userid"]))
+    _fill_input(d, "customer-email", _scoped_email(context, row["email"]))
+    _click_send(d)
+    _wait_admin_request_done(d)
+    body = _parse_admin_json(d)
+    if body and body.get("id"):
+        context.created_customer_ids.append(int(body["id"]))
 
 
 @when("I retrieve the customer by id")
 def step_retrieve_customer(context):
-    customer_id = context.customer["id"]
-    context.resp = requests.get(
-        f"{context.BASE_URL}/customers/{customer_id}", timeout=10
-    )
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "read")
+    cid = str(context.customer["id"])
+    _fill_input(d, "customer-id", cid)
+    _click_send(d)
+    _wait_admin_request_done(d)
 
 
 @when("I request the list of customers")
 def step_list_customers(context):
-    context.resp = requests.get(context.BASE_URL + "/customers", timeout=10)
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "list")
+    _click_send(d)
+    _wait_admin_request_done(d)
 
 
 @when("I delete the customer by id")
 def step_delete_customer(context):
-    customer_id = context.customer["id"]
-    context.resp = requests.delete(
-        f"{context.BASE_URL}/customers/{customer_id}", timeout=10
-    )
-    if customer_id in context.created_customer_ids:
-        context.created_customer_ids.remove(customer_id)
-
-
-@then("the response status code should be {status_code:d}")
-def step_check_status_code(context, status_code):
-    assert context.resp.status_code == status_code, (
-        f"Expected {status_code}, got {context.resp.status_code}: {context.resp.text}"
-    )
-
-
-@then('the response should contain "{text}"')
-def step_response_contains(context, text):
-    assert text in context.resp.text, (
-        f"Expected '{text}' in response: {context.resp.text}"
-    )
-
-
-@then("the response should be a list")
-def step_response_is_list(context):
-    data = context.resp.json()
-    assert isinstance(data, list), f"Expected a list, got: {type(data)}"
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "delete")
+    cid = str(context.customer["id"])
+    _fill_input(d, "customer-id", cid)
+    _click_send(d)
+    _wait_admin_request_done(d)
+    cid_int = int(context.customer["id"])
+    if cid_int in context.created_customer_ids:
+        context.created_customer_ids.remove(cid_int)
 
 
 @when("I update the customer with the following data")
 def step_update_customer(context):
     row = context.table[0]
-    payload = {
-        "name": row["name"],
-        "userid": row["userid"],
-        "email": row["email"],
-    }
-    customer_id = context.customer["id"]
-    context.resp = requests.put(
-        f"{context.BASE_URL}/customers/{customer_id}",
-        json=payload,
-        headers=context.headers,
-        timeout=10,
-    )
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "update")
+    _fill_input(d, "customer-id", str(context.customer["id"]))
+    _fill_input(d, "customer-name", row["name"])
+    _fill_input(d, "customer-userid", _scoped_userid(context, row["userid"]))
+    _fill_input(d, "customer-email", _scoped_email(context, row["email"]))
+    _click_send(d)
+    _wait_admin_request_done(d)
 
 
 @when('I query customers by name "{name}"')
 def step_query_customers_by_name(context, name):
-    context.resp = requests.get(
-        f"{context.BASE_URL}/customers?name={name}", timeout=10
-    )
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "query")
+    _fill_input(d, "query-name", name)
+    _click_send(d)
+    _wait_admin_request_done(d)
 
 
 @when("I activate the customer by id")
 def step_activate_customer(context):
-    customer_id = context.customer["id"]
-    context.resp = requests.put(
-        f"{context.BASE_URL}/customers/{customer_id}/activate",
-        headers=context.headers,
-        timeout=10,
+    _open_admin(context)
+    d = context.driver
+    _select_operation(d, "activate")
+    _fill_input(d, "customer-id", str(context.customer["id"]))
+    _click_send(d)
+    _wait_admin_request_done(d)
+
+
+@then("the response status code should be {status_code:d}")
+def step_check_status_code(context, status_code):
+    if getattr(context, "last_http_status", None) is not None:
+        assert context.last_http_status == status_code, (
+            f"expected HTTP {status_code}, got {context.last_http_status}"
+        )
+        return
+    raw = context.driver.find_element(By.ID, "admin-page").get_attribute(
+        "data-last-http-status"
     )
+    assert raw == str(status_code), f"expected HTTP {status_code}, got {raw!r}"
+
+
+@then('the response should contain "{text}"')
+def step_response_contains(context, text):
+    ht = getattr(context, "health_response_text", None)
+    if ht is not None:
+        assert text in ht, f"expected substring {text!r} in health body"
+        return
+    if "/admin" in context.driver.current_url:
+        body = _admin_result_text(context.driver)
+    else:
+        body = context.driver.page_source
+    assert text in body, f"expected substring {text!r} in {body[:500]}"
+
+
+@then("the response should be a list")
+def step_response_is_list(context):
+    data = _parse_admin_json(context.driver)
+    assert isinstance(data, list), f"Expected JSON list in admin result, got {data!r}"

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -38,6 +38,14 @@ def create_app():
     from service.models import db
     db.init_app(app)
 
+    @app.before_request
+    def _clear_stale_db_session():
+        """Avoid leaking a failed transaction across requests on the same worker thread."""
+        try:
+            db.session.rollback()
+        except Exception:  # pylint: disable=broad-except
+            db.session.remove()
+
     with app.app_context():
         # Dependencies require we import the routes AFTER the Flask app is created
         # pylint: disable=wrong-import-position, wrong-import-order, unused-import
@@ -51,7 +59,10 @@ def create_app():
             db.create_all()
         except Exception as error:  # pylint: disable=broad-except
             app.logger.critical("%s: Cannot continue", error)
-            # gunicorn requires exit code 4 to stop spawning workers when they die
+            # Under pytest, re-raise so collection shows the real DB error instead of
+            # SystemExit (INTERNALERROR). Gunicorn still uses exit code 4 on failure.
+            if "pytest" in sys.modules:
+                raise
             sys.exit(4)
 
         # Set up logging for production

--- a/service/models.py
+++ b/service/models.py
@@ -171,7 +171,7 @@ class Customer(db.Model):  # pylint: disable=too-many-instance-attributes
     def find(cls, by_id):
         """Finds a Customer by it's ID"""
         logger.info("Processing lookup for id %s ...", by_id)
-        return cls.query.session.get(cls, by_id)
+        return db.session.get(cls, by_id)
 
     @classmethod
     def find_by_name(cls, name):

--- a/service/templates/admin/index.html
+++ b/service/templates/admin/index.html
@@ -272,7 +272,7 @@
     }
   </style>
 </head>
-<body id="admin-page">
+<body id="admin-page" data-last-http-status="">
   <header>
     <h1>Customers Admin</h1>
     <p>Internal console for staff — choose an operation and fill only the fields that apply.</p>
@@ -409,6 +409,23 @@
   function setStatus(msg, ok) {
     statusEl.textContent = msg || "";
     statusEl.className = ok === true ? "ok" : ok === false ? "err" : "";
+  }
+
+  function setLastHttpStatus(code) {
+    var root = $("admin-page");
+    if (root) {
+      root.setAttribute(
+        "data-last-http-status",
+        code === null || code === undefined ? "" : String(code)
+      );
+    }
+  }
+
+  async function doFetchWithStatus(url, options) {
+    setLastHttpStatus("");
+    const r = await fetch(url, options);
+    setLastHttpStatus(String(r.status));
+    return r;
   }
 
   function showResult(data) {
@@ -592,7 +609,7 @@
       }
       setStatus("Creating…", null);
       try {
-        const r = await fetch("/customers", {
+        const r = await doFetchWithStatus("/customers", {
           method: "POST",
           headers: jsonHeaders(),
           body: JSON.stringify({
@@ -620,7 +637,7 @@
       if (!f.id) { setStatus("Customer ID is required.", false); return; }
       setStatus("Loading…", null);
       try {
-        const r = await fetch("/customers/" + encodeURIComponent(f.id), { headers: { Accept: "application/json" } });
+        const r = await doFetchWithStatus("/customers/" + encodeURIComponent(f.id), { headers: { Accept: "application/json" } });
         const text = await r.text();
         let body;
         try { body = text ? JSON.parse(text) : null; } catch { body = text; }
@@ -649,7 +666,7 @@
       }
       setStatus("Updating…", null);
       try {
-        const r = await fetch("/customers/" + encodeURIComponent(f.id), {
+        const r = await doFetchWithStatus("/customers/" + encodeURIComponent(f.id), {
           method: "PUT",
           headers: jsonHeaders(),
           body: JSON.stringify({
@@ -679,7 +696,7 @@
       if (!f.id) { setStatus("Customer ID is required.", false); return; }
       setStatus("Deleting…", null);
       try {
-        const r = await fetch("/customers/" + encodeURIComponent(f.id), { method: "DELETE" });
+        const r = await doFetchWithStatus("/customers/" + encodeURIComponent(f.id), { method: "DELETE" });
         const text = await r.text();
         let body;
         try { body = text ? JSON.parse(text) : null; } catch { body = text; }
@@ -698,8 +715,10 @@
     if (op === "list") {
       setStatus("Loading list…", null);
       try {
-        const r = await fetch("/customers", { headers: { Accept: "application/json" } });
-        const body = await r.json();
+        const r = await doFetchWithStatus("/customers", { headers: { Accept: "application/json" } });
+        const text = await r.text();
+        let body;
+        try { body = text ? JSON.parse(text) : null; } catch { body = text; }
         showResult(body);
         statusFromResponse(
           r,
@@ -719,10 +738,12 @@
       if (!q) { setStatus("Enter a name to filter.", false); return; }
       setStatus("Querying…", null);
       try {
-        const r = await fetch("/customers?name=" + encodeURIComponent(q), {
+        const r = await doFetchWithStatus("/customers?name=" + encodeURIComponent(q), {
           headers: { Accept: "application/json" },
         });
-        const body = await r.json();
+        const text = await r.text();
+        let body;
+        try { body = text ? JSON.parse(text) : null; } catch { body = text; }
         showResult(body);
         statusFromResponse(r, body, "Query complete.", "Query failed");
         if (r.ok) trySyncCustomersTable(body);
@@ -736,7 +757,7 @@
       if (!f.id) { setStatus("Customer ID is required.", false); return; }
       setStatus("Activating…", null);
       try {
-        const r = await fetch("/customers/" + encodeURIComponent(f.id) + "/activate", {
+        const r = await doFetchWithStatus("/customers/" + encodeURIComponent(f.id) + "/activate", {
           method: "PUT",
           headers: { Accept: "application/json" },
         });
@@ -758,6 +779,7 @@
   $("admin-operation").addEventListener("change", () => {
     syncFieldGroups();
     setStatus("", null);
+    setLastHttpStatus("");
   });
   $("btn-execute").addEventListener("click", runOperation);
 

--- a/tests/test_create_app_coverage.py
+++ b/tests/test_create_app_coverage.py
@@ -1,0 +1,64 @@
+######################################################################
+# Copyright 2016, 2024 John J. Rofrano. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######################################################################
+"""
+Exercise create_app() and before_request branches for coverage (Codecov patch).
+"""
+
+import logging
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+import wsgi
+from service import create_app
+from service.models import db
+
+DATABASE_URI = os.getenv(
+    "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+)
+
+
+class TestCreateAppLifecycle(TestCase):
+    """service.__init__: session reset hook and create_all failure under pytest."""
+
+    @classmethod
+    def setUpClass(cls):
+        wsgi.app.config.setdefault("TESTING", True)
+        wsgi.app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+        wsgi.app.logger.setLevel(logging.CRITICAL)
+
+    def tearDown(self):
+        with wsgi.app.app_context():
+            try:
+                db.session.remove()
+            except RuntimeError:
+                pass
+
+    def test_before_request_calls_remove_when_rollback_raises(self):
+        """If rollback() fails, before_request still clears the session via remove()."""
+        client = wsgi.app.test_client()
+        with patch.object(db.session, "rollback", side_effect=RuntimeError("rollback")):
+            with patch.object(db.session, "remove") as mock_remove:
+                resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        mock_remove.assert_called()
+
+    def test_create_all_failure_is_reraised_under_pytest(self):
+        """db.create_all() errors propagate when pytest is loaded (no sys.exit)."""
+        with patch.object(db, "create_all", side_effect=RuntimeError("no db")):
+            with self.assertRaises(RuntimeError) as ctx:
+                create_app()
+        self.assertIn("no db", str(ctx.exception))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,11 @@ import os
 import logging
 from unittest import TestCase
 from unittest.mock import patch
+
+from sqlalchemy.exc import IntegrityError
+
 from wsgi import app
+from service import models as models_module
 from service.models import Customer, db, DataValidationError
 from .factories import CustomerFactory
 
@@ -185,6 +189,113 @@ class TestCustomerModel(TestCase):
             profile.deserialize,
             "this is not a dict",
         )
+
+    def test_deserialize_attribute_error(self):
+        """It should wrap AttributeError from bad payload shapes."""
+
+        class _BadDict(dict):
+            def __getitem__(self, key):
+                if key == "name":
+                    raise AttributeError("simulated")
+                return super().__getitem__(key)
+
+        profile = Customer()
+        bad = _BadDict([("name", "x"), ("userid", "u1"), ("email", "e@e.com")])
+        with self.assertRaises(DataValidationError) as ctx:
+            profile.deserialize(bad)
+        self.assertIn("simulated", str(ctx.exception))
+
+    def test_find_by_userid(self):
+        """It should find a customer by userid and return None when missing."""
+        profile = CustomerFactory(userid="findme_uid", email="findme_uid@example.com")
+        profile.create()
+        found = Customer.find_by_userid("findme_uid")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.id, profile.id)
+        self.assertIsNone(Customer.find_by_userid("no_such_userid_xyz"))
+
+    def test_friendly_integrity_message_userid(self):
+        """_friendly_integrity_message maps userid unique violations."""
+        orig = Exception("duplicate key value violates unique constraint ix_customer_userid")
+        exc = IntegrityError("stmt", {}, orig)
+        msg = models_module._friendly_integrity_message(exc)
+        self.assertIn("user id", msg.lower())
+
+    def test_friendly_integrity_message_email(self):
+        """_friendly_integrity_message maps email unique violations."""
+        orig = Exception("duplicate key value violates unique constraint ix_customer_email")
+        exc = IntegrityError("stmt", {}, orig)
+        msg = models_module._friendly_integrity_message(exc)
+        self.assertIn("email", msg.lower())
+
+    def test_friendly_integrity_message_generic_unique(self):
+        """Unknown unique constraint still returns a short combined message."""
+        orig = Exception("duplicate key value violates unique constraint ix_other")
+        exc = IntegrityError("stmt", {}, orig)
+        msg = models_module._friendly_integrity_message(exc)
+        self.assertIn("user id or email", msg.lower())
+
+    def test_friendly_integrity_message_fallback(self):
+        """When no pattern matches, return the generic save message."""
+        orig = Exception("some database failure")
+        exc = IntegrityError("stmt", {}, orig)
+        msg = models_module._friendly_integrity_message(exc)
+        self.assertIn("constraint", msg.lower())
+
+    def test_create_integrity_error_duplicate_userid(self):
+        """create() maps IntegrityError to DataValidationError for duplicate userid."""
+        a = CustomerFactory(userid="same_uid", email="a_dup@example.com")
+        a.create()
+        b = CustomerFactory(userid="same_uid", email="b_dup@example.com")
+        with self.assertRaises(DataValidationError) as ctx:
+            b.create()
+        self.assertIn("user id", str(ctx.exception).lower())
+
+    def test_create_integrity_error_duplicate_email(self):
+        """create() maps email unique IntegrityError (DB message) to DataValidationError."""
+        profile = Customer(name="EmailDup", userid="u_email_dup", email="edup@example.com")
+        profile.id = None
+        orig = Exception("UNIQUE constraint failed: customer.email")
+        err = IntegrityError("stmt", {}, orig)
+        with patch("service.models.db.session.commit", side_effect=err):
+            with self.assertRaises(DataValidationError) as ctx:
+                profile.create()
+        self.assertIn("email", str(ctx.exception).lower())
+
+    def test_create_generic_error_message_truncated(self):
+        """Very long non-integrity errors are shortened in the API message."""
+        profile = Customer(name="LongErr", userid="long_err_u", email="long_err@example.com")
+        profile.id = None
+        long_msg = "x" * 300
+        with patch(
+            "service.models.db.session.commit", side_effect=RuntimeError(long_msg)
+        ):
+            with self.assertRaises(DataValidationError) as ctx:
+                profile.create()
+        self.assertIn("server logs", str(ctx.exception).lower())
+
+    def test_update_integrity_error_message(self):
+        """update() maps IntegrityError through _friendly_integrity_message."""
+        profile = CustomerFactory()
+        profile.create()
+        orig = Exception("duplicate key email ix_customer_email")
+        err = IntegrityError("stmt", {}, orig)
+        with patch("service.models.db.session.commit", side_effect=err):
+            with self.assertRaises(DataValidationError) as ctx:
+                profile.update()
+        self.assertIn("email", str(ctx.exception).lower())
+
+    def test_update_generic_error_message_truncated(self):
+        """Very long non-integrity errors on update are shortened."""
+        profile = CustomerFactory()
+        profile.create()
+        long_msg = "y" * 300
+        with patch(
+            "service.models.db.session.commit", side_effect=RuntimeError(long_msg)
+        ):
+            with self.assertRaises(DataValidationError) as ctx:
+                profile.update()
+        self.assertIn("server logs", str(ctx.exception).lower())
 
     def test_find_by_name_not_found(self):
         """It should return empty list when name not found"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -96,6 +96,7 @@ class TestCustomerService(TestCase):
         self.assertIn('id="admin-operation"', html)
         self.assertIn('id="admin-page"', html)
         self.assertIn('id="admin-customers-table"', html)
+        self.assertIn("data-last-http-status", html)
 
     def test_create_customer(self):
         """It should Create a new Customer"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -149,6 +149,17 @@ class TestCustomerService(TestCase):
         updated = Customer.find(customer.id)
         self.assertEqual(updated.name, "Bob")
 
+    def test_update_customer_validation_error_returns_400(self):
+        """It should return 400 when update payload fails deserialize validation."""
+        customer = CustomerFactory()
+        customer.create()
+        resp = self.client.put(
+            f"/customers/{customer.id}",
+            json={"name": "Incomplete"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_delete_customer(self):
         """It should Delete a Customer"""
         customer = CustomerFactory()


### PR DESCRIPTION
## Summary
This PR updates the manager admin console workflow, hardens Behave/Selenium BDD against flaky browser and DB state, and improves local/CI ergonomics.

## Changes
- **BDD**: Steps drive `/admin` only (no Python HTTP client); per-scenario userid/email suffix; browser-based DB wipe in hooks; Chrome options and timeouts tuned for headless runs.
- **Admin UI**: List/query operations read responses with `text` + JSON parse (consistent with other ops); `data-last-http-status` for assertions.
- **Backend**: `@app.before_request` rolls back the scoped session so a failed transaction cannot leak across requests on the same worker thread; `Customer.find` uses `db.session.get`.
- **Pytest**: If `db.create_all()` fails while pytest is loaded, re-raise the exception instead of `sys.exit(4)` so collection reports a real `OperationalError` when Postgres is down.
- **Tooling**: `make bdd` runs `python -m behave`; Pipfile Python pin relaxed; Tekton task optional Chromium install for Linux BDD.

## How to verify
- `DATABASE_URI=sqlite:////tmp/t.db pipenv run pytest -q --cov=service --cov-fail-under=95`
- With Postgres + app running: `BASE_URL=http://localhost:8080 pipenv run python -m behave`
