### PR TITLE
OpenShift Tekton GitHub webhook (EventListener route + RBAC)

### DIFF
--- a/.tekton/eventlistener-route.yaml
+++ b/.tekton/eventlistener-route.yaml
@@ -1,0 +1,19 @@
+---
+# OpenShift Route exposing the Tekton EventListener service created from:
+#   kind: EventListener
+#   metadata.name: github-webhook
+#
+# Tekton Triggers creates a Service named: el-<eventlistener-name>
+# => el-github-webhook
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: github-webhook
+spec:
+  to:
+    kind: Service
+    name: el-github-webhook
+    weight: 100
+  port:
+    targetPort: http-listener
+  wildcardPolicy: None

--- a/.tekton/rbac-eventlistener-cluster.yaml
+++ b/.tekton/rbac-eventlistener-cluster.yaml
@@ -1,0 +1,18 @@
+# One-time per cluster (or per team namespace): lets the EventListener pod use CEL and other
+# ClusterInterceptors. After applying triggers.yaml, run:
+#
+#   oc apply -f .tekton/rbac-eventlistener-cluster.yaml
+#   oc create clusterrolebinding tekton-triggers-el-interceptors \
+#     --clusterrole=tekton-triggers-el-interceptors \
+#     --serviceaccount="$(oc project -q):tekton-triggers-sa"
+#
+# If the binding already exists, oc will error — that is OK.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-triggers-el-interceptors
+rules:
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clusterinterceptors"]
+    verbs: ["get", "list", "watch"]

--- a/.tekton/triggers.yaml
+++ b/.tekton/triggers.yaml
@@ -10,8 +10,11 @@ metadata:
   name: tekton-triggers-role
 rules:
   - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns"]
-    verbs: ["create"]
+    resources: ["pipelineruns", "pipelineruns/status"]
+    verbs: ["create", "get", "list", "watch", "patch", "update"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
     verbs: ["get", "list", "watch"]
@@ -62,10 +65,6 @@ spec:
             value: $(tt.params.repo-url)
           - name: revision
             value: $(tt.params.revision)
-          - name: image
-            value: cluster-registry:5000/customers:$(tt.params.revision)
-          - name: base-url
-            value: http://customers
         workspaces:
           - name: source
             volumeClaimTemplate:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ deploy: ## Deploy the service on local Kubernetes
 	$(info Deploying service locally...)
 	kubectl apply -R -f k8s/
 
+.PHONY: tekton-openshift
+tekton-openshift: ## Apply Tekton manifests and expose GitHub webhook EventListener Route (oc login first)
+	$(info Applying Tekton pipeline, tasks, triggers, webhook RBAC, and EventListener route...)
+	oc apply -f .tekton/workspace.yaml -f .tekton/tasks.yaml -f .tekton/pipeline.yaml -f .tekton/triggers.yaml
+	oc apply -f .tekton/rbac-eventlistener-cluster.yaml
+	-oc create clusterrolebinding tekton-triggers-el-interceptors --clusterrole=tekton-triggers-el-interceptors --serviceaccount="$$(oc project -q):tekton-triggers-sa"
+	oc apply -f .tekton/eventlistener-route.yaml
+
 ############################################################
 # COMMANDS FOR BUILDING THE IMAGE
 ############################################################

--- a/README.md
+++ b/README.md
@@ -85,6 +85,31 @@ make lint
 
 ---
 
+## OpenShift: Tekton GitHub webhook (EventListener)
+
+After **`oc login`** and **`oc project <your-namespace>`**:
+
+1. Apply pipeline, tasks, triggers, CEL interceptor RBAC, and the Route that exposes the listener:
+   ```bash
+   make tekton-openshift
+   ```
+   Or: `oc apply -f .tekton/` then apply **`.tekton/rbac-eventlistener-cluster.yaml`**, create the **ClusterRoleBinding** (see comments in that file), and **`oc apply -f .tekton/eventlistener-route.yaml`**.
+
+2. Webhook URL for GitHub (**push** events; trigger filters **`master`**):
+   ```bash
+   oc get route github-webhook -o jsonpath='https://{.spec.host}{"\n"}'
+   ```
+   Use `http://` instead of `https://` if your Route has no TLS. Payload URL should be `https://<host>/` (or `http://...`).
+
+3. Confirm a push to **`master`** creates a PipelineRun:
+   ```bash
+   oc get pipelineruns
+   ```
+
+If the EventListener pod is in **CrashLoopBackOff**, ensure the **ClusterRoleBinding** for **`tekton-triggers-sa`** to **`tekton-triggers-el-interceptors`** exists (CEL needs **clusterinterceptors** read access).
+
+---
+
 ## Project layout
 
 ```text


### PR DESCRIPTION
## Summary
Adds Tekton Triggers hardening and OpenShift Route for the GitHub webhook EventListener.

## Changes
- `.tekton/triggers.yaml`: broader Role for `tekton-triggers-sa`; TriggerTemplate uses pipeline defaults for `image` / `base-url`
- `.tekton/rbac-eventlistener-cluster.yaml`: ClusterRole for CEL `clusterinterceptors` (with ClusterRoleBinding instructions)
- `.tekton/eventlistener-route.yaml`: Route `github-webhook` → `el-github-webhook`
- `Makefile`: `make tekton-openshift`
- `README.md`: webhook setup steps

## Verify
`oc login` → `oc project <ns>` → `make tekton-openshift` → webhook URL from `oc get route github-webhook` → push to `master` → `oc get pipelineruns`