### PR TITLE
OpenShift external access: Customers Route + Service port

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -90,10 +90,20 @@ spec:
       workingDir: $(workspaces.source.path)
       script: |
         #!/usr/bin/env bash
-        set -e
-        echo "Deploying image $(params.image) to cluster..."
-        oc apply -R -f k8s/
-        echo "Deployment manifests applied."
+        set -euo pipefail
+        NS="$(oc project -q)"
+        echo "Deploying to namespace ${NS} with image $(params.image)"
+        oc apply -n "${NS}" -f k8s/postgres/
+        oc rollout status -n "${NS}" statefulset/postgres --timeout=180s
+        oc apply -n "${NS}" -f k8s/deployment.yaml -f k8s/service.yaml
+        oc set image -n "${NS}" deployment/customers customers="$(params.image)" --record
+        oc rollout status -n "${NS}" deployment/customers --timeout=300s
+        if oc get crd routes.route.openshift.io &>/dev/null; then
+          oc apply -n "${NS}" -f k8s/openshift/route.yaml
+        else
+          oc apply -n "${NS}" -f k8s/ingress.yaml
+        fi
+        echo "Deployment applied."
 ---
 apiVersion: tekton.dev/v1
 kind: Task

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ deploy: ## Deploy the service on local Kubernetes
 	$(info Deploying service locally...)
 	kubectl apply -R -f k8s/
 
+.PHONY: deploy-openshift
+deploy-openshift: ## Deploy Postgres + app + OpenShift Route (oc login + oc project first)
+	$(info Deploying Postgres, app, and Route on OpenShift...)
+	oc apply -f k8s/postgres/
+	oc rollout status statefulset/postgres --timeout=180s
+	oc apply -f k8s/deployment.yaml -f k8s/service.yaml
+	oc apply -f k8s/openshift/route.yaml
+
 .PHONY: tekton-openshift
 tekton-openshift: ## Apply Tekton manifests and expose GitHub webhook EventListener Route (oc login first)
 	$(info Applying Tekton pipeline, tasks, triggers, webhook RBAC, and EventListener route...)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ If the EventListener pod is in **CrashLoopBackOff**, ensure the **ClusterRoleBin
 
 ---
 
+## OpenShift: external access (Customers API Route)
+
+The **Customers** `Service` exposes port **80** → pod **8080** with a named port **`http`** so an OpenShift **Route** can set **`spec.port.targetPort: http`** unambiguously.
+
+After **`oc login`** and **`oc project <your-namespace>`**:
+
+1. Ensure the deployment image is pullable in that namespace (build/push to the internal registry or `oc set image` as in your pipeline).
+2. Apply app + Route:
+   ```bash
+   make deploy-openshift
+   ```
+   Or manually: `oc apply -f k8s/postgres/` (wait for Postgres), then `oc apply -f k8s/deployment.yaml -f k8s/service.yaml`, then **`oc apply -f k8s/openshift/route.yaml`**.
+3. Open the app host and check health:
+   ```bash
+   oc get route customers -o jsonpath='https://{.spec.host}{"\n"}'
+   ```
+   Use `http://` if your Route has no TLS. Then `curl -sS -i "https://<host>/health"` (or `http://`) should return **200**.
+
+On plain Kubernetes, keep using **`k8s/ingress.yaml`**; the CD **deploy** task applies **Route** when the Route CRD exists, otherwise **Ingress**.
+
+---
+
 ## Project layout
 
 ```text

--- a/k8s/openshift/route.yaml
+++ b/k8s/openshift/route.yaml
@@ -1,0 +1,16 @@
+# OpenShift Route (route.openshift.io). Use on OpenShift; skip on plain Kubernetes (use ingress.yaml).
+# targetPort must match a port name on Service customers (see k8s/service.yaml: name http -> pod 8080).
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: customers
+  labels:
+    app: customers
+spec:
+  to:
+    kind: Service
+    name: customers
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -6,6 +6,7 @@ spec:
   selector:
     app: customers
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 8080


### PR DESCRIPTION
## Summary
Exposes the Customers API on OpenShift with a **Route** and a **named Service port** so `targetPort: http` is unambiguous.

## Changes
- `k8s/service.yaml`: port name `http` (80 → 8080)
- `k8s/openshift/route.yaml`: Route `customers` → Service `customers`, `targetPort: http`
- `Makefile`: `make deploy-openshift` (postgres → deployment + service → route)
- `.tekton/tasks.yaml` `deploy` task: ordered deploy, `oc set image`, apply Route if Route CRD exists else Ingress
- `README.md`: how to verify `oc get route customers` and `/health`

## Verify
`oc login` → `oc project <ns>` → `make deploy-openshift` → `oc get route customers` → curl Route host `/health`