### PR TITLE
fix: K3D deployment image matches make build/push

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
         - name: customers
-          image: image-registry.openshift-image-registry.svc:5000/nj672-dev/customers:latest
+          # Matches Makefile default (K3D + embedded registry). On OpenShift, use oc set image or the pipeline image param.
+          image: cluster-registry:5000/customers:1.0
           imagePullPolicy: IfNotPresent
           command: ["gunicorn"]
           args: ["--bind", "0.0.0.0:8080", "wsgi:app"]


### PR DESCRIPTION
Prof/TA grading with `make cluster`, `make build`, `make push`, `make deploy` needs the Deployment to reference `cluster-registry:5000/customers:1.0`, not the OpenShift internal registry.

OpenShift teams can still `oc set image` or rely on the CD pipeline image parameter.